### PR TITLE
Nn 1997 locked attendance api attribute

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/controllers/AttendanceController.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/controllers/AttendanceController.java
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.whereabouts.dto.AttendanceDto;
 import uk.gov.justice.digital.hmpps.whereabouts.dto.CreateAttendanceDto;
 import uk.gov.justice.digital.hmpps.whereabouts.dto.UpdateAttendanceDto;
 import uk.gov.justice.digital.hmpps.whereabouts.model.TimePeriod;
+import uk.gov.justice.digital.hmpps.whereabouts.services.AttendanceLocked;
 import uk.gov.justice.digital.hmpps.whereabouts.services.AttendanceNotFound;
 import uk.gov.justice.digital.hmpps.whereabouts.services.AttendanceService;
 
@@ -57,6 +58,8 @@ public class AttendanceController {
             attendanceService.updateAttendance(id, attendance);
         } catch (AttendanceNotFound e) {
             return ResponseEntity.notFound().build();
+        } catch (AttendanceLocked e) {
+            return ResponseEntity.badRequest().build();
         }
 
         return ResponseEntity.noContent().build();

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/dto/AttendanceDto.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/dto/AttendanceDto.java
@@ -35,4 +35,5 @@ public class AttendanceDto {
     private LocalDateTime modifyDateTime;
     private String modifyUserId;
     private Long caseNoteId;
+    private Boolean locked;
 }

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/AttendanceLocked.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/AttendanceLocked.java
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.whereabouts.services;
+
+public class AttendanceLocked extends Exception {}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/AttendanceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/AttendanceServiceTest.kt
@@ -105,6 +105,157 @@ class AttendanceServiceTest {
                         .createUserId("user")
                         .createDateTime(now)
                         .caseNoteId(1)
+                        .locked(false)
+                        .build()
+        ))
+    }
+
+    @Test
+    fun `should return locked true when attendance unpaid 7 days ago`() {
+        val sevenDaysAgoTime = LocalDateTime.now().minusDays(7)
+
+        `when`(attendanceRepository
+                .findByPrisonIdAndEventLocationIdAndEventDateAndPeriod("LEI", 1, sevenDaysAgoTime.toLocalDate(), TimePeriod.AM))
+                .thenReturn(setOf(
+                        Attendance.
+                                builder()
+                                .id(1)
+                                .absentReason(AbsentReason.Refused)
+                                .attended(false)
+                                .paid(false)
+                                .eventId(2)
+                                .eventLocationId(3)
+                                .period(TimePeriod.AM)
+                                .prisonId("LEI")
+                                .offenderBookingId(100)
+                                .eventDate(sevenDaysAgoTime.toLocalDate())
+                                .createUserId("user")
+                                .createDateTime(sevenDaysAgoTime)
+                                .caseNoteId(1)
+                                .build()
+                ))
+
+        val service =  AttendanceService(attendanceRepository, nomisService)
+
+        val result = service.getAttendance("LEI" , 1, sevenDaysAgoTime.toLocalDate(), TimePeriod.AM)
+
+        assertThat(result).containsAnyElementsOf(mutableListOf(
+                AttendanceDto
+                        .builder()
+                        .id(1)
+                        .absentReason(AbsentReason.Refused)
+                        .attended(false)
+                        .paid(false)
+                        .eventId(2)
+                        .eventLocationId(3)
+                        .period(TimePeriod.AM)
+                        .prisonId("LEI")
+                        .bookingId(100)
+                        .eventDate(sevenDaysAgoTime.toLocalDate())
+                        .createUserId("user")
+                        .createDateTime(sevenDaysAgoTime)
+                        .caseNoteId(1)
+                        .locked(true)
+                        .build()
+        ))
+    }
+
+    @Test
+    fun `should return locked false when attendance unpaid under 7 days ago`() {
+        val sixDaysAgoTime = LocalDateTime.now().minusDays(6)
+
+        `when`(attendanceRepository
+                .findByPrisonIdAndEventLocationIdAndEventDateAndPeriod("LEI", 1, sixDaysAgoTime.toLocalDate(), TimePeriod.AM))
+                .thenReturn(setOf(
+                        Attendance.
+                                builder()
+                                .id(1)
+                                .absentReason(AbsentReason.Refused)
+                                .attended(false)
+                                .paid(false)
+                                .eventId(2)
+                                .eventLocationId(3)
+                                .period(TimePeriod.AM)
+                                .prisonId("LEI")
+                                .offenderBookingId(100)
+                                .eventDate(sixDaysAgoTime.toLocalDate())
+                                .createUserId("user")
+                                .createDateTime(sixDaysAgoTime)
+                                .caseNoteId(1)
+                                .build()
+                ))
+
+        val service =  AttendanceService(attendanceRepository, nomisService)
+
+        val result = service.getAttendance("LEI" , 1, sixDaysAgoTime.toLocalDate(), TimePeriod.AM)
+
+        assertThat(result).containsAnyElementsOf(mutableListOf(
+                AttendanceDto
+                        .builder()
+                        .id(1)
+                        .absentReason(AbsentReason.Refused)
+                        .attended(false)
+                        .paid(false)
+                        .eventId(2)
+                        .eventLocationId(3)
+                        .period(TimePeriod.AM)
+                        .prisonId("LEI")
+                        .bookingId(100)
+                        .eventDate(sixDaysAgoTime.toLocalDate())
+                        .createUserId("user")
+                        .createDateTime(sixDaysAgoTime)
+                        .caseNoteId(1)
+                        .locked(false)
+                        .build()
+        ))
+    }
+
+    @Test
+    fun `should return locked true when attendance paid yesterday`() {
+        val yesterdayTime = LocalDateTime.now().minusDays(1)
+
+        `when`(attendanceRepository
+                .findByPrisonIdAndEventLocationIdAndEventDateAndPeriod("LEI", 1, yesterdayTime.toLocalDate(), TimePeriod.AM))
+                .thenReturn(setOf(
+                        Attendance.
+                                builder()
+                                .id(1)
+                                .absentReason(AbsentReason.Refused)
+                                .attended(false)
+                                .paid(true)
+                                .eventId(2)
+                                .eventLocationId(3)
+                                .period(TimePeriod.AM)
+                                .prisonId("LEI")
+                                .offenderBookingId(100)
+                                .eventDate(yesterdayTime.toLocalDate())
+                                .createUserId("user")
+                                .createDateTime(yesterdayTime)
+                                .caseNoteId(1)
+                                .build()
+                ))
+
+        val service =  AttendanceService(attendanceRepository, nomisService)
+
+        val result = service.getAttendance("LEI" , 1, yesterdayTime.toLocalDate(), TimePeriod.AM)
+
+        assertThat(result).containsAnyElementsOf(mutableListOf(
+                AttendanceDto
+                        .builder()
+                        .id(1)
+                        .absentReason(AbsentReason.Refused)
+                        .attended(false)
+                        .paid(true)
+                        .eventId(2)
+                        .eventLocationId(3)
+                        .period(TimePeriod.AM)
+                        .prisonId("LEI")
+                        .bookingId(100)
+                        .eventDate(yesterdayTime.toLocalDate())
+                        .createUserId("user")
+                        .createDateTime(yesterdayTime)
+                        .caseNoteId(1)
+                        .locked(true)
                         .build()
         ))
     }
@@ -526,6 +677,31 @@ class AttendanceServiceTest {
     }
 
     @Test
+    fun `should throw an AttendanceLocked`() {
+        val yesterday = LocalDate.now().minusDays(1)
+
+        `when`(attendanceRepository.findById(1)).thenReturn(
+                Optional.of(Attendance
+                        .builder()
+                        .id(1)
+                        .attended(true)
+                        .paid(true)
+                        .eventId(1)
+                        .eventLocationId(2)
+                        .eventDate(yesterday)
+                        .prisonId("LEI")
+                        .offenderBookingId(1)
+                        .period(TimePeriod.AM)
+                        .build()))
+
+        val service = AttendanceService(attendanceRepository, nomisService)
+
+        assertThatThrownBy {
+            service.updateAttendance(1, UpdateAttendanceDto.builder().paid(false).attended(false).build())
+        }.isExactlyInstanceOf(AttendanceLocked::class.java)
+    }
+
+    @Test
     fun `should return attendance dto on creation` () {
 
         stubCaseNote(100L)
@@ -560,6 +736,7 @@ class AttendanceServiceTest {
                 .period(TimePeriod.AM)
                 .eventDate(LocalDate.now())
                 .comments("test comments")
+                .locked(false)
                 .build())
     }
 


### PR DESCRIPTION
Returns `true` if the attendance was paid a day or more ago OR if the attendance was unpaid and happened 7 or more days ago. Else returns `false`. An update request to a locked attendance returns 400.