### PR TITLE
Nn 1976 push att comment and update case note text

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/AttendanceService.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/AttendanceService.java
@@ -135,11 +135,12 @@ public class AttendanceService {
         if (caseNoteId == null && reason != null && AbsentReason.getIepTriggers().contains(reason)) {
             log.info("IEP Warning created for bookingId {}", bookingId);
 
+            final var modifiedTextWithReason = reason + " - " + text;
             final var caseNote = nomisService.postCaseNote(
                     bookingId,
                     "NEG",//"Negative Behaviour"
                     "IEP_WARN", //"IEP Warning",
-                    text,
+                    modifiedTextWithReason,
                     LocalDateTime.now());
              return Optional.of(caseNote.getCaseNoteId());
         }

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/AttendanceService.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/AttendanceService.java
@@ -124,7 +124,8 @@ public class AttendanceService {
         final var eventOutcome = nomisEventOutcomeMapper.getEventOutcome(
                 attendance.getAbsentReason(),
                 attendance.getAttended(),
-                attendance.getPaid());
+                attendance.getPaid(),
+                attendance.getComments());
 
         log.info("Updating attendance on NOMIS {} {}", attendance.toBuilder().comments(null).build(), eventOutcome);
 

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/EventOutcome.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/EventOutcome.java
@@ -4,10 +4,11 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
-@Data
+@Data()
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 class EventOutcome {
     private final String eventOutcome;
     private final String performance;
+    private String outcomeComment;
 }

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/EventOutcome.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/EventOutcome.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
-@Data()
+@Data
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 class EventOutcome {

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/NomisEventOutcomeMapper.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/NomisEventOutcomeMapper.java
@@ -8,21 +8,21 @@ class NomisEventOutcomeMapper {
     private static final HashMap<AbsentReason, EventOutcome> eventOutcomes = new HashMap<>();
 
     NomisEventOutcomeMapper() {
-        eventOutcomes.put(AbsentReason.AcceptableAbsence, new EventOutcome("ACCAB", null));
-        eventOutcomes.put(AbsentReason.NotRequired, new EventOutcome("NREQ", null));
+        eventOutcomes.put(AbsentReason.AcceptableAbsence, new EventOutcome("ACCAB", null, null));
+        eventOutcomes.put(AbsentReason.NotRequired, new EventOutcome("NREQ", null, null));
 
-        eventOutcomes.put(AbsentReason.SessionCancelled, new EventOutcome("CANC", null));
-        eventOutcomes.put(AbsentReason.RestInCell, new EventOutcome("REST", null));
+        eventOutcomes.put(AbsentReason.SessionCancelled, new EventOutcome("CANC", null, null));
+        eventOutcomes.put(AbsentReason.RestInCell, new EventOutcome("REST", null, null));
 
-        eventOutcomes.put(AbsentReason.Sick, new EventOutcome("REST", null));
-        eventOutcomes.put(AbsentReason.RestDay, new EventOutcome("REST", null));
+        eventOutcomes.put(AbsentReason.Sick, new EventOutcome("REST", null, null));
+        eventOutcomes.put(AbsentReason.RestDay, new EventOutcome("REST", null, null));
 
-        eventOutcomes.put(AbsentReason.Refused, new EventOutcome("UNACAB", null));
-        eventOutcomes.put(AbsentReason.UnacceptableAbsence, new EventOutcome("UNACAB", null));
+        eventOutcomes.put(AbsentReason.Refused, new EventOutcome("UNACAB", null, null));
+        eventOutcomes.put(AbsentReason.UnacceptableAbsence, new EventOutcome("UNACAB", null, null));
 
     }
 
-    EventOutcome getEventOutcome(final AbsentReason reason, final boolean attended, final boolean paid) {
+    EventOutcome getEventOutcome(final AbsentReason reason, final boolean attended, final boolean paid, final String comment) {
 
         if (attended && reason != null) {
             throw new IllegalArgumentException("An absent reason was supplied for a valid attendance");
@@ -33,7 +33,7 @@ class NomisEventOutcomeMapper {
         }
 
         if (attended && paid)
-            return new EventOutcome("ATT", "STANDARD");
+            return new EventOutcome("ATT", "STANDARD", comment);
 
         if (paid && !AbsentReason.getPaidReasons().contains(reason)) {
             throw new IllegalArgumentException(String.format("%s is not a valid paid reason", reason));
@@ -43,7 +43,13 @@ class NomisEventOutcomeMapper {
             throw new IllegalArgumentException(String.format("%s is not a valid unpaid reason", reason));
         }
 
-        return eventOutcomes.get(reason);
+        var outcome = eventOutcomes.get(reason);
+
+        if (comment != null) {
+            outcome.setOutcomeComment(comment);
+        }
+
+        return outcome;
 
     }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/integration/AttendanceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/integration/AttendanceIntegrationTest.kt
@@ -116,14 +116,15 @@ class AttendanceIntegrationTest : IntegrationTest () {
 
         verify(putRequestedFor(urlEqualTo(updateAttendanceUrl)).withRequestBody(
                 equalToJson(gson.toJson(mapOf(
-                        "eventOutcome" to "UNACAB"
+                        "eventOutcome" to "UNACAB",
+                        "outcomeComment" to "Test comment"
                 )))
         ))
 
         verify(postRequestedFor(urlEqualTo(createCaseNote))
                 .withRequestBody(matchingJsonPath("$[?(@.type == 'NEG')]"))
                 .withRequestBody(matchingJsonPath("$[?(@.subType == 'IEP_WARN')]"))
-                .withRequestBody(matchingJsonPath("$[?(@.text == '$comments')]"))
+                .withRequestBody(matchingJsonPath("$[?(@.text == 'Refused - $comments')]"))
                 .withRequestBody(matchingJsonPath("$.occurrence"))
         )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/AttendanceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/AttendanceServiceTest.kt
@@ -479,7 +479,7 @@ class AttendanceServiceTest {
                         eq(attendance.bookingId),
                         eq("NEG"),
                         eq("IEP_WARN"),
-                        eq("hello"),
+                        eq("UnacceptableAbsence - hello"),
                         isA(LocalDateTime::class.java))
     }
 
@@ -533,7 +533,7 @@ class AttendanceServiceTest {
                         eq(attendance.bookingId),
                         eq("NEG"),
                         eq("IEP_WARN"),
-                        eq("test comment"),
+                        eq("Refused - test comment"),
                         isA(LocalDateTime::class.java))
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/AttendanceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/AttendanceServiceTest.kt
@@ -301,7 +301,7 @@ class AttendanceServiceTest {
         service.createAttendance(attendance)
 
         verify(nomisService).putAttendance(attendance.bookingId,
-                attendance.eventId, EventOutcome("ATT", "STANDARD"))
+                attendance.eventId, EventOutcome("ATT", "STANDARD", attendance.comments))
 
     }
 
@@ -321,7 +321,7 @@ class AttendanceServiceTest {
         service.createAttendance(attendance)
 
         verify(nomisService).putAttendance(attendance.bookingId,
-                attendance.eventId, EventOutcome("ACCAB", null))
+                attendance.eventId, EventOutcome("ACCAB", null, "hello"))
     }
 
     @Test
@@ -339,7 +339,7 @@ class AttendanceServiceTest {
         service.createAttendance(attendance)
 
         verify(nomisService).putAttendance(attendance.bookingId,
-                attendance.eventId, EventOutcome("NREQ", null))
+                attendance.eventId, EventOutcome("NREQ", null, "hello"))
     }
 
     @Test
@@ -357,7 +357,7 @@ class AttendanceServiceTest {
         service.createAttendance(attendance)
 
         verify(nomisService).putAttendance(attendance.bookingId,
-                attendance.eventId, EventOutcome("CANC", null))
+                attendance.eventId, EventOutcome("CANC", null, "hello"))
     }
 
     @Test
@@ -375,7 +375,7 @@ class AttendanceServiceTest {
         service.createAttendance(attendance)
 
         verify(nomisService).putAttendance(attendance.bookingId,
-                attendance.eventId, EventOutcome("REST", null))
+                attendance.eventId, EventOutcome("REST", null, "hello"))
     }
 
     @Test
@@ -393,7 +393,7 @@ class AttendanceServiceTest {
         service.createAttendance(attendance)
 
         verify(nomisService).putAttendance(attendance.bookingId,
-                attendance.eventId, EventOutcome("REST", null))
+                attendance.eventId, EventOutcome("REST", null, "hello"))
     }
 
     @Test
@@ -411,7 +411,7 @@ class AttendanceServiceTest {
         service.createAttendance(attendance)
 
         verify(nomisService).putAttendance(attendance.bookingId,
-                attendance.eventId, EventOutcome("REST", null))
+                attendance.eventId, EventOutcome("REST", null, "hello"))
     }
 
     @Test
@@ -432,7 +432,7 @@ class AttendanceServiceTest {
         service.createAttendance(attendance)
 
         verify(nomisService).putAttendance(attendance.bookingId,
-                attendance.eventId, EventOutcome("UNACAB", null))
+                attendance.eventId, EventOutcome("UNACAB", null, "hello"))
     }
 
     @Test
@@ -454,7 +454,7 @@ class AttendanceServiceTest {
         service.createAttendance(attendance)
 
         verify(nomisService).putAttendance(attendance.bookingId,
-                attendance.eventId, EventOutcome("UNACAB", null))
+                attendance.eventId, EventOutcome("UNACAB", null, "hello"))
     }
 
     @Test
@@ -506,7 +506,7 @@ class AttendanceServiceTest {
                         eq(attendance.bookingId),
                         eq("NEG"),
                         eq("IEP_WARN"),
-                        eq("hello"),
+                        eq("Refused - hello"),
                         isA(LocalDateTime::class.java))
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/NomisEventOutcomeMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/NomisEventOutcomeMapperTest.kt
@@ -15,7 +15,7 @@ class NomisEventOutcomeMapperTest {
             val reason = it
 
             assertThatThrownBy {
-                eventOutcomeMapper.getEventOutcome(reason, false, true)
+                eventOutcomeMapper.getEventOutcome(reason, false, true, null)
             }.hasMessage(String.format("%s is not a valid paid reason", reason))
         }
     }
@@ -29,7 +29,7 @@ class NomisEventOutcomeMapperTest {
             val reason = it
 
             assertThatThrownBy {
-                eventOutcomeMapper.getEventOutcome(reason, false, false)
+                eventOutcomeMapper.getEventOutcome(reason, false, false, null)
             }.hasMessage(String.format("%s is not a valid unpaid reason", reason))
         }
     }
@@ -37,14 +37,14 @@ class NomisEventOutcomeMapperTest {
     @Test
     fun `should throw an exception when an absent reason is supplied for a a valid attendance`() {
         assertThatThrownBy {
-            eventOutcomeMapper.getEventOutcome(AbsentReason.SessionCancelled, true, true)
+            eventOutcomeMapper.getEventOutcome(AbsentReason.SessionCancelled, true, true, null)
         }.hasMessage("An absent reason was supplied for a valid attendance")
     }
 
     @Test
     fun `should make absent reason required when attendance is not set`() {
         assertThatThrownBy {
-            eventOutcomeMapper.getEventOutcome(null, false, true)
+            eventOutcomeMapper.getEventOutcome(null, false, true, null)
         }.hasMessage("An absent reason was not supplied")
     }
 }


### PR DESCRIPTION
This does two things:
1. Pushes the attendance comment to NOMIS (current only stored in this API's database)
2. Prepends a case note with the absence reason to provide more context for the IEP warning.