### PR TITLE
Nn 2410 fix unaccounted for am pm bug

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/AttendanceStatistics.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/AttendanceStatistics.kt
@@ -29,25 +29,19 @@ open class AttendanceStatistics(private val attendanceRepository: AttendanceRepo
 
     val attendancesBookingIdsCount = attendances.groupingBy { it.bookingId }.eachCount()
 
-    var notRecorded = 0
-
     // Iterate over the scheduled booking ids grouping
     // and check whether the number of times that booking
     // id appears in the schedules matches the number of times
     // it appears in the attendances. If not, the difference
     // is added
-
-    scheduledBookingIdsCount.keys.forEach {
-      if(!attendancesBookingIdsCount.containsKey(it)) {
-        notRecorded += scheduledBookingIdsCount.getValue(it)
-      } else if(scheduledBookingIdsCount.getValue(it) != attendancesBookingIdsCount.getValue(it)) {
-        notRecorded += scheduledBookingIdsCount.getValue(it) - attendancesBookingIdsCount.getValue(it)
-      }
+    var notRecordedCount = 0
+    for (key in scheduledBookingIdsCount.keys) {
+      notRecordedCount += if (!attendancesBookingIdsCount.containsKey(key)) scheduledBookingIdsCount.getValue(key) else scheduledBookingIdsCount.getValue(key) - attendancesBookingIdsCount.getValue(key)
     }
 
     return Stats(
         scheduleActivities = offendersScheduledForActivity.count(),
-        notRecorded = notRecorded,
+        notRecorded = notRecordedCount,
         paidReasons = PaidReasons(
             attended = attendances.count { it.attended },
             acceptableAbsence = attendances.count { it.absentReason == AbsentReason.AcceptableAbsence },

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/AttendanceStatistics.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/AttendanceStatistics.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.whereabouts.services
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.whereabouts.model.AbsentReason
+import uk.gov.justice.digital.hmpps.whereabouts.model.Attendance
 import uk.gov.justice.digital.hmpps.whereabouts.model.TimePeriod
 import uk.gov.justice.digital.hmpps.whereabouts.repository.AttendanceRepository
 import java.time.LocalDate
@@ -17,31 +18,14 @@ open class AttendanceStatistics(private val attendanceRepository: AttendanceRepo
     val periods = period?.let { setOf(it) } ?: setOf(TimePeriod.PM, TimePeriod.AM)
     val offendersScheduledForActivity = getScheduleActivityForPeriods(prisonId, from, to, periods)
 
-    // This creates a Grouping that looks like {1=2, 2=2}
-    // Where the key is the booking id and the value is the
-    // number of times that booking id appears
-    val scheduledBookingIdsCount = offendersScheduledForActivity.groupingBy { it }.eachCount()
-
     val attendances = when (periods.size) {
       in 2..3 -> attendanceRepository.findByPrisonIdAndEventDateBetweenAndPeriodIn(prisonId, from, to, periods)
       else -> attendanceRepository.findByPrisonIdAndPeriodAndEventDateBetween(prisonId, period, from, to)
     }
 
-    val attendancesBookingIdsCount = attendances.groupingBy { it.bookingId }.eachCount()
-
-    // Iterate over the scheduled booking ids grouping
-    // and check whether the number of times that booking
-    // id appears in the schedules matches the number of times
-    // it appears in the attendances. If not, the difference
-    // is added
-    var notRecordedCount = 0
-    for (key in scheduledBookingIdsCount.keys) {
-      notRecordedCount += if (!attendancesBookingIdsCount.containsKey(key)) scheduledBookingIdsCount.getValue(key) else scheduledBookingIdsCount.getValue(key) - attendancesBookingIdsCount.getValue(key)
-    }
-
     return Stats(
         scheduleActivities = offendersScheduledForActivity.count(),
-        notRecorded = notRecordedCount,
+        notRecorded = calculateNotRecorded(offendersScheduledForActivity, attendances),
         paidReasons = PaidReasons(
             attended = attendances.count { it.attended },
             acceptableAbsence = attendances.count { it.absentReason == AbsentReason.AcceptableAbsence },
@@ -60,4 +44,24 @@ open class AttendanceStatistics(private val attendanceRepository: AttendanceRepo
 
   private fun getScheduleActivityForPeriods(prisonId: String, from: LocalDate, to: LocalDate, periods: Set<TimePeriod>): List<Long> =
       periods.map { elite2ApiService.getBookingIdsForScheduleActivitiesByDateRange(prisonId, it, from, to) }.flatten()
+
+  private fun calculateNotRecorded(scheduledBookingIds: List<Long>, attendedBookingIds: Set<Attendance>): Int {
+    // This creates a Grouping that looks like {1=2, 2=2}
+    // Where the key is the booking id and the value is the
+    // number of times that booking id appears
+    val scheduledBookingIdsCount = scheduledBookingIds.groupingBy { it }.eachCount()
+    val attendancesBookingIdsCount = attendedBookingIds.groupingBy { it.bookingId }.eachCount()
+
+    // Iterate over the scheduled booking ids grouping
+    // and check whether the number of times that booking
+    // id appears in the schedules matches the number of times
+    // it appears in the attendances. If not, the difference
+    // is added
+    return scheduledBookingIdsCount.keys.map {
+      if (!attendancesBookingIdsCount.containsKey(it))
+        scheduledBookingIdsCount.getValue(it)
+      else
+        scheduledBookingIdsCount.getValue(it) - attendancesBookingIdsCount.getValue(it)
+    }.fold(0) { acc, current -> acc + current}
+  }
 }

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/AttendanceStatistics.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/AttendanceStatistics.kt
@@ -17,16 +17,37 @@ open class AttendanceStatistics(private val attendanceRepository: AttendanceRepo
     val periods = period?.let { setOf(it) } ?: setOf(TimePeriod.PM, TimePeriod.AM)
     val offendersScheduledForActivity = getScheduleActivityForPeriods(prisonId, from, to, periods)
 
+    // This creates a Grouping that looks like {1=2, 2=2}
+    // Where the key is the booking id and the value is the
+    // number of times that booking id appears
+    val scheduledBookingIdsCount = offendersScheduledForActivity.groupingBy { it }.eachCount()
+
     val attendances = when (periods.size) {
       in 2..3 -> attendanceRepository.findByPrisonIdAndEventDateBetweenAndPeriodIn(prisonId, from, to, periods)
       else -> attendanceRepository.findByPrisonIdAndPeriodAndEventDateBetween(prisonId, period, from, to)
     }
 
-    val attendanceBookingIds = attendances.map { it.bookingId }
+    val attendancesBookingIdsCount = attendances.groupingBy { it.bookingId }.eachCount()
+
+    var notRecorded = 0
+
+    // Iterate over the scheduled booking ids grouping
+    // and check whether the number of times that booking
+    // id appears in the schedules matches the number of times
+    // it appears in the attendances. If not, the difference
+    // is added
+
+    scheduledBookingIdsCount.keys.forEach {
+      if(!attendancesBookingIdsCount.containsKey(it)) {
+        notRecorded += scheduledBookingIdsCount.getValue(it)
+      } else if(scheduledBookingIdsCount.getValue(it) != attendancesBookingIdsCount.getValue(it)) {
+        notRecorded += scheduledBookingIdsCount.getValue(it) - attendancesBookingIdsCount.getValue(it)
+      }
+    }
 
     return Stats(
         scheduleActivities = offendersScheduledForActivity.count(),
-        notRecorded = offendersScheduledForActivity.count { !attendanceBookingIds.contains(it) },
+        notRecorded = notRecorded,
         paidReasons = PaidReasons(
             attended = attendances.count { it.attended },
             acceptableAbsence = attendances.count { it.absentReason == AbsentReason.AcceptableAbsence },


### PR DESCRIPTION
Currently when users select 'AM + PM' from the dropdown on the whereabouts statistics page, we're only counting people who have been unaccounted for for both periods. Instead, this is supposed to be a cumulative list. This fixes this by comparing number of schedules to number of attendances per booking id.