### PR TITLE
DT-526 Endpoint to retrieve agency locations by group

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/controllers/LocationController.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/controllers/LocationController.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.whereabouts.controllers
+
+import io.swagger.annotations.*
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.whereabouts.dto.ErrorResponse
+import uk.gov.justice.digital.hmpps.whereabouts.model.Location
+import uk.gov.justice.digital.hmpps.whereabouts.services.LocationService
+
+@Api(tags = ["locations"])
+@RestController
+@RequestMapping(value = ["locations"], produces = [MediaType.APPLICATION_JSON_VALUE])
+class LocationController(private val locationService: LocationService) {
+
+  @GetMapping("/groups/{agencyId}/{name}")
+  @ApiOperation(value = "List of cell locations by group at agency location.", notes = "List of cell locations by group at agency location.", nickname = "getLocationGroup")
+  @ApiResponses(value = [
+    ApiResponse(code = 200, message = "OK", response = Location::class, responseContainer = "List"),
+    ApiResponse(code = 400, message = "Invalid request.", response = ErrorResponse::class, responseContainer = "List"),
+    ApiResponse(code = 404, message = "Requested resource not found.", response = ErrorResponse::class, responseContainer = "List"),
+    ApiResponse(code = 500, message = "Unrecoverable error occurred whilst processing request.", response = ErrorResponse::class, responseContainer = "List")
+  ])
+  fun getLocationGroup(@ApiParam(value = "The prison", required = true) @PathVariable("agencyId") agencyId: String,
+                       @ApiParam(value = "The group name", required = true) @PathVariable("name") name: String): List<Location>
+    = locationService.getCellLocationsForGroup(agencyId, name)
+
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/integration/LocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/integration/LocationIntegrationTest.kt
@@ -1,0 +1,85 @@
+package uk.gov.justice.digital.hmpps.whereabouts.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.springframework.boot.test.web.client.exchange
+import org.springframework.http.HttpMethod
+import org.springframework.http.ResponseEntity
+import uk.gov.justice.digital.hmpps.whereabouts.dto.ErrorResponse
+import uk.gov.justice.digital.hmpps.whereabouts.model.Location
+
+class LocationIntegrationTest: IntegrationTest() {
+
+  @Test
+  fun `location groups for agency by location name - defined in properties - selects relevant locations only`() {
+    elite2MockServer.stubAgencyLocationsByType("RNI", "CELL", getRniHb7Locations())
+
+    val response: ResponseEntity<String> =
+        restTemplate.exchange("/locations/groups/RNI/House block 7", HttpMethod.GET, createHeaderEntity(""))
+
+    assertThatJsonFileAndStatus(response, 200, "RNI_location_groups_agency_locname.json");
+  }
+
+  @Test
+  fun `location groups for agency by location name - defined in elite2 - selects relevant locations only`() {
+    elite2MockServer.stubAgencyLocationsByType("LEI", "CELL", getLeiHb7Locations())
+
+    val response: ResponseEntity<String> =
+        restTemplate.exchange("/locations/groups/LEI/House_block_7", HttpMethod.GET, createHeaderEntity(""))
+
+    assertThatJsonFileAndStatus(response, 200, "LEI_location_groups_agency_locname.json");
+  }
+
+  @Test
+  fun `location groups for agency by location name - agency locations not found - returns not found`() {
+    elite2MockServer.stubGetAgencyLocationsByTypeNotFound("not_an_agency", "CELL")
+
+    val response: ResponseEntity<ErrorResponse> =
+        restTemplate.exchange("/locations/groups/not_an_agency/House block 7", HttpMethod.GET, createHeaderEntity(""))
+
+    assertThat(response.statusCodeValue).isEqualTo(404)
+    assertThat(response.body.developerMessage).contains("not found").contains("not_an_agency").contains("CELL")
+  }
+
+  @Test
+  fun `location groups for agency by location name - server error from elite2 - server error passed to client`() {
+    elite2MockServer.stubGetAgencyLocationsByTypeServerError("any_agency", "CELL")
+
+    val response: ResponseEntity<String> =
+        restTemplate.exchange("/locations/groups/any_agency/any_location_type", HttpMethod.GET, createHeaderEntity(""))
+
+    assertThat(response.statusCodeValue).isEqualTo(500)
+    assertThat(response.body).contains("Server error")
+  }
+
+  private fun getRniHb7Locations() =
+      listOf(
+          aLocation(locationId = 507011, description = "Hb7-1-002", agencyId = "RNI", locationPrefix = "RNI-HB7-1-002"),
+          aLocation(locationId = 507031, description = "Hb7-1-021", agencyId = "RNI", locationPrefix = "RNI-HB7-1-021"),
+          aLocation(locationId = 108582, description = "S-1-001",   agencyId = "RNI", locationPrefix = "RNI-S-1-001"),
+          aLocation(locationId = 108583, description = "S-1-002",   agencyId = "RNI", locationPrefix = "RNI-S-1-002")
+      )
+
+  private fun getLeiHb7Locations() =
+      listOf(
+          aLocation(locationId = 507011, description = "House_block_7-1-002", agencyId = "LEI", locationPrefix = "LEI-House-block-7-1-002"),
+          aLocation(locationId = 507031, description = "House_block_7-1-021", agencyId = "LEI", locationPrefix = "LEI-House-block-7-1-021"),
+          aLocation(locationId = 108582, description = "S-1-001",   agencyId = "LEI", locationPrefix = "LEI-S-1-001"),
+          aLocation(locationId = 108583, description = "S-1-002",   agencyId = "LEI", locationPrefix = "LEI-S-1-002")
+      )
+
+  private fun aLocation(locationId: Long, description: String, agencyId: String, locationPrefix: String) =
+      Location(
+          locationId = locationId,
+          locationType = "CELL",
+          description = description,
+          agencyId = agencyId,
+          currentOccupancy = 0,
+          locationPrefix = locationPrefix,
+          operationalCapacity = 0,
+          userDescription = "",
+          internalLocationCode = "",
+          locationUsage = "",
+          parentLocationId = null
+      )
+}

--- a/src/test/resources/uk/gov/justice/digital/hmpps/whereabouts/integration/LEI_location_groups_agency_locname.json
+++ b/src/test/resources/uk/gov/justice/digital/hmpps/whereabouts/integration/LEI_location_groups_agency_locname.json
@@ -1,0 +1,26 @@
+[
+  {
+    "locationId": 507011,
+    "locationType": "CELL",
+    "description": "House_block_7-1-002",
+    "locationUsage": "",
+    "agencyId": "LEI",
+    "currentOccupancy": 0,
+    "locationPrefix": "LEI-House-block-7-1-002",
+    "operationalCapacity": 0,
+    "userDescription": "",
+    "internalLocationCode": ""
+  },
+  {
+    "locationId": 507031,
+    "locationType": "CELL",
+    "description": "House_block_7-1-021",
+    "locationUsage": "",
+    "agencyId": "LEI",
+    "currentOccupancy": 0,
+    "locationPrefix": "LEI-House-block-7-1-021",
+    "operationalCapacity": 0,
+    "userDescription": "",
+    "internalLocationCode": ""
+  }
+]

--- a/src/test/resources/uk/gov/justice/digital/hmpps/whereabouts/integration/RNI_location_groups_agency_locname.json
+++ b/src/test/resources/uk/gov/justice/digital/hmpps/whereabouts/integration/RNI_location_groups_agency_locname.json
@@ -1,0 +1,26 @@
+[
+  {
+    "locationId": 507011,
+    "locationType": "CELL",
+    "description": "Hb7-1-002",
+    "locationUsage": "",
+    "agencyId": "RNI",
+    "currentOccupancy": 0,
+    "locationPrefix": "RNI-HB7-1-002",
+    "operationalCapacity": 0,
+    "userDescription": "",
+    "internalLocationCode": ""
+  },
+  {
+    "locationId": 507031,
+    "locationType": "CELL",
+    "description": "Hb7-1-021",
+    "locationUsage": "",
+    "agencyId": "RNI",
+    "currentOccupancy": 0,
+    "locationPrefix": "RNI-HB7-1-021",
+    "operationalCapacity": 0,
+    "userDescription": "",
+    "internalLocationCode": ""
+  }
+]


### PR DESCRIPTION
This was previously removed from whereabouts as it wasn't needed - but it is required now to get a list of locations for a group name so that we can retrieve the schedules for those locations.