### PR TITLE
DCS-698 make video link bookings from appointments. 

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/model/VideoLinkAppointment.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/model/VideoLinkAppointment.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.whereabouts.model
 
 import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
@@ -20,6 +22,8 @@ data class VideoLinkAppointment(
   val bookingId: Long,
   val appointmentId: Long,
   val court: String,
+
+  @Enumerated(EnumType.STRING)
   val hearingType: HearingType,
   val createdByUsername: String? = null,
   val madeByTheCourt: Boolean? = true

--- a/src/main/resources/db/migration/V15__video_link_appointment_hearing_type_migration.sql
+++ b/src/main/resources/db/migration/V15__video_link_appointment_hearing_type_migration.sql
@@ -1,0 +1,3 @@
+UPDATE video_link_appointment set hearing_type = 'MAIN' where hearing_type = '0';
+UPDATE video_link_appointment set hearing_type = 'PRE'  where hearing_type = '1';
+UPDATE video_link_appointment set hearing_type = 'POST' where hearing_type = '2';

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/repository/VideoLinkBookingRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/repository/VideoLinkBookingRepositoryTest.kt
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
+import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.transaction.TestTransaction
 import org.springframework.transaction.annotation.Transactional
@@ -26,6 +27,9 @@ class VideoLinkBookingRepositoryTest {
 
   @MockBean
   lateinit var authenticationFacade: AuthenticationFacade
+
+  @Autowired
+  lateinit var jdbcTemplate: JdbcTemplate
 
   @Test
   fun `should persist a booking (main only)`() {
@@ -99,5 +103,8 @@ class VideoLinkBookingRepositoryTest {
     val persistentBooking = persistentBookingOptional.get()
 
     assertThat(persistentBooking).isEqualToIgnoringGivenFields(transientBooking, "id")
+
+    val hearingTypes = jdbcTemplate.queryForList("select hearing_type from video_link_appointment", String::class.java)
+    assertThat(hearingTypes).contains("PRE", "MAIN", "POST")
   }
 }


### PR DESCRIPTION
Fix problems with HearingType enum mapping:

1. Change this mapping so that persisted values are the strings 'PRE', 'MAIN' and 'POST'. 
1. Migrate the values in the video_link_appointment.hearing_type column from '0', '1', '2' to 'PRE', 'MAIN' and 'POST'.