### PR TITLE
DCS-778 Fix swagger documentation

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/config/ResourceServerConfiguration.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/config/ResourceServerConfiguration.java
@@ -20,7 +20,9 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 import uk.gov.justice.digital.hmpps.whereabouts.controllers.AttendanceController;
 import uk.gov.justice.digital.hmpps.whereabouts.security.AuthAwareTokenConverter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.Optional;
@@ -76,8 +78,11 @@ public class ResourceServerConfiguration extends WebSecurityConfigurerAdapter {
                 .build();
 
         docket.genericModelSubstitutes(Optional.class);
-        docket.directModelSubstitute(ZonedDateTime.class, java.util.Date.class);
-        docket.directModelSubstitute(LocalDateTime.class, java.util.Date.class);
+
+        docket.directModelSubstitute(ZonedDateTime.class, String.class);
+        docket.directModelSubstitute(LocalDateTime.class, String.class);
+        docket.directModelSubstitute(LocalDate.class, String.class);
+        docket.directModelSubstitute(LocalTime.class, String.class);
 
         return docket;
     }

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/locationfinder/AppointmentLocationsService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/locationfinder/AppointmentLocationsService.kt
@@ -39,7 +39,7 @@ class AppointmentLocationsService(
     prisonApiService
       .getAgencyLocationsForTypeUnrestricted(specification.agencyId, "APP")
       .filter { it.locationType == "VIDE" }
-      .map { Location(it.locationId, it.description) }
+      .map { LocationIdAndDescription(it.locationId, it.description) }
 
   private fun fetchScheduledAppointments(specification: AppointmentLocationsSpecification) =
     prisonApiService
@@ -50,7 +50,7 @@ class AppointmentLocationsService(
   companion object {
     private fun toAvailableLocations(
       locationsForAppointmentIntervals: List<AppointmentIntervalLocations>,
-      locations: List<Location>
+      locations: List<LocationIdAndDescription>
     ): List<AvailableLocations> {
       val locationsById = locations.associateBy { it.locationId }
       return locationsForAppointmentIntervals

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/locationfinder/model.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/locationfinder/model.kt
@@ -8,7 +8,7 @@ import javax.validation.constraints.NotBlank
 
 @ApiModel(description = "A specification that returned locations should satisfy.")
 data class AppointmentLocationsSpecification(
-  @ApiModelProperty(value = "The appointment intervals are all on this date.", example = "2021-01-01")
+  @ApiModelProperty(value = "The appointment intervals are all on this date. ISO-8601 date format (YYYY-MM-DD)", example = "2021-01-01")
   val date: LocalDate,
 
   @ApiModelProperty(value = "The locations must be within the agency (prison) having this identifier.", example = "WWI")
@@ -33,15 +33,15 @@ data class AppointmentLocationsSpecification(
  */
 @ApiModel(description = "A closed time interval, being the intervening time between two time points including the start and end points themselves")
 data class Interval(
-  @ApiModelProperty(value = "The time at which the interval starts, inclusive.", example = "T09:00")
+  @ApiModelProperty(value = "The time at which the interval starts, inclusive. ISO-8601 format (hh:mm)", example = "09:00")
   val start: LocalTime,
 
-  @ApiModelProperty(value = "The time at which the interval end, inclusive.", example = "T09:30")
+  @ApiModelProperty(value = "The time at which the interval end, inclusive. ISO-8601 format (hh:mm)", example = "09:30")
   val end: LocalTime
 )
 
 /**
- * Internal data class corresponding to AvaialbleLocations.  This version holds the locations as as
+ * Internal data class corresponding to AvailableLocations.  This version holds the locations as as
  * a mutable set of Long so that it may be built up over time.
  *
  * TODO: I'd give this package visibility, but I 'm not sure know how to do that in Kotlin.
@@ -60,7 +60,7 @@ data class AppointmentIntervalLocations(
 }
 
 @ApiModel(description = "A minimal representation of a NOMIS agency internal location.")
-data class Location(
+data class LocationIdAndDescription(
   @ApiModelProperty(value = "The NOMIS agency internal location identifier of the location", example = "12345")
   val locationId: Long,
 
@@ -78,5 +78,5 @@ data class AvailableLocations(
   val appointmentInterval: Interval,
 
   @ApiModelProperty(value = "The locations that may be booked for the duration of the appointment interval.")
-  val locations: List<Location>
+  val locations: List<LocationIdAndDescription>
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/controllers/CourtControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/controllers/CourtControllerTest.kt
@@ -30,7 +30,7 @@ import uk.gov.justice.digital.hmpps.whereabouts.services.locationfinder.Appointm
 import uk.gov.justice.digital.hmpps.whereabouts.services.locationfinder.AppointmentLocationsSpecification
 import uk.gov.justice.digital.hmpps.whereabouts.services.locationfinder.AvailableLocations
 import uk.gov.justice.digital.hmpps.whereabouts.services.locationfinder.Interval
-import uk.gov.justice.digital.hmpps.whereabouts.services.locationfinder.Location
+import uk.gov.justice.digital.hmpps.whereabouts.services.locationfinder.LocationIdAndDescription
 import uk.gov.justice.digital.hmpps.whereabouts.utils.UserMdcFilter
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -613,14 +613,14 @@ class CourtControllerTest : TestController() {
             AvailableLocations(
               Interval(LocalTime.of(9, 30), LocalTime.of(10, 0)),
               listOf(
-                Location(1L, "Location 1")
+                LocationIdAndDescription(1L, "Location 1")
               )
             ),
             AvailableLocations(
               Interval(LocalTime.of(12, 30), LocalTime.of(13, 0)),
               listOf(
-                Location(2L, "Location 2"),
-                Location(3L, "Location 3")
+                LocationIdAndDescription(2L, "Location 2"),
+                LocationIdAndDescription(3L, "Location 3")
               )
             )
           )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/locationfinder/AppointmentLocationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/locationfinder/AppointmentLocationsServiceTest.kt
@@ -335,14 +335,14 @@ class AppointmentLocationsServiceTest {
       AvailableLocations(
         interval1,
         listOf(
-          Location(1L, "L1"),
-          Location(2L, "L2")
+          LocationIdAndDescription(1L, "L1"),
+          LocationIdAndDescription(2L, "L2")
         )
       ),
       AvailableLocations(
         interval2,
         listOf(
-          Location(2L, "L2")
+          LocationIdAndDescription(2L, "L2")
         )
       )
     )


### PR DESCRIPTION
* LocalDate, LocalTime, LocalDate etcTime and ZonedDateTime now mapped to String instead of java.util.Date
* Fixed swagger doc for Location  by re-naming to LocationIdAndDescription because SpringFox couldn't handle  two classes having the same name.