### PR TITLE
DCS-982-whereabouts-api new /courts endpoint to serve hardcoded court…

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/controllers/CourtController.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/controllers/CourtController.kt
@@ -49,7 +49,7 @@ class CourtController(
   )
   fun getCourtLocations() = CourtLocationResponse(courtLocations = courtService.getCourtLocations())
 
-  @GetMapping(produces = [MediaType.APPLICATION_JSON_VALUE], path = ["/courts"])
+  @GetMapping(produces = [MediaType.APPLICATION_JSON_VALUE], path = ["/ids"])
   @ResponseStatus(HttpStatus.OK)
   @ApiOperation(
     value = "Court Ids",

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/controllers/CourtController.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/controllers/CourtController.kt
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.whereabouts.dto.CourtIdsResponse
 import uk.gov.justice.digital.hmpps.whereabouts.dto.CourtLocationResponse
 import uk.gov.justice.digital.hmpps.whereabouts.dto.VideoLinkAppointmentsResponse
 import uk.gov.justice.digital.hmpps.whereabouts.dto.VideoLinkBookingResponse
@@ -47,6 +48,15 @@ class CourtController(
     notes = "Return all court locations"
   )
   fun getCourtLocations() = CourtLocationResponse(courtLocations = courtService.getCourtLocations())
+
+  @GetMapping(produces = [MediaType.APPLICATION_JSON_VALUE], path = ["/courts"])
+  @ResponseStatus(HttpStatus.OK)
+  @ApiOperation(
+    value = "Court Ids",
+    response = CourtIdsResponse::class,
+    notes = "Return court Ids"
+  )
+  fun getCourtIds() = CourtIdsResponse(courtIds = courtService.getCourtIds())
 
   @PostMapping(produces = [MediaType.APPLICATION_JSON_VALUE], path = ["/video-link-appointments"])
   @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/dto/AppointmentDtos.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/dto/AppointmentDtos.kt
@@ -10,6 +10,9 @@ import java.time.LocalDateTime
 data class CourtLocationResponse(val courtLocations: Set<String>? = emptySet())
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
+data class CourtIdsResponse(val courtIds: Set<String>? = emptySet())
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class VideoLinkAppointmentsResponse(val appointments: Set<VideoLinkAppointmentDto>? = emptySet())
 
 data class CreateBookingAppointment(

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/CourtService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/CourtService.kt
@@ -34,13 +34,16 @@ class CourtService(
   private val videoLinkBookingRepository: VideoLinkBookingRepository,
   private val clock: Clock,
   private val videoLinkBookingEventListener: VideoLinkBookingEventListener,
-  @Value("\${courts}") private val courts: String
+  @Value("\${courts}") private val courts: String,
+  @Value("\${courtIds}") private val courtIds: String,
 ) {
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
   fun getCourtLocations() = courts.split(",").toSet()
+
+  fun getCourtIds() = courtIds.split(",").toSet()
 
   @Transactional(readOnly = true)
   fun getVideoLinkAppointments(appointmentIds: Set<Long>): Set<VideoLinkAppointmentDto> {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,10 @@ azure.application-insights.web.enable-W3C=true
 
 courts=Birmingham Immigration,Bromley,Caernarfon County,Caernarfon Crown,Caernarfon Magistrates,Cheltenham,City of London,Coventry Crown,Coventry Magistrates,Croydon Crown,Croydon Magistrates,Derby,Dudley,Hereford Crown,Hereford Magistrates,Inner London,Kidderminster,Kingston upon Thames,Leamington,Llandrindod Wells Justice Centre,Llandudno,Mold Crown,Mold County,Mold Magistrates,Prestatyn County,Redditch,Shrewsbury Crown,Shrewsbury Magistrates,South Derbyshire,Southwark,Telford,Thames,Walsall,Warwick,Welshpool County,Welshpool Magistrates,Westminster,Wimbledon,Wolverhampton Crown,Wolverhampton Magistrates,Wood Green,Woolwich,Worcester Crown,Worcester Magistrates,Wrexham County,Wrexham Magistrates
 
+courtIds=BROMMC,CRNRCT,CRNRCC,CRNHMC,CHELMC,CITYMC,CVNTCC,CVNTMC,CRYDCC,CRYDMC,DRBYCC,DUDLMC,HERFCC,HERFMC,INNRCC,KIDDMC,KNGTCC,LEAMMC,LLNWMC,LLDUMC,MOLDCC,MOLDCT,MOLDMC,PRSTMC,RDDTMC,SHRWCC,SHREMC,DRBYMC,STHWCC,TELFMC,THMSMC,WALSMC,WRWKCC,WLSHCT,WLSHMC,CRT034,WMBLMC,WLVRCC,WLVRMC,WDGRCC,WOOLCC,WRCSCC,WRCSMC,WREXCT,WREXMC
+
+
+
 elite2api.endpoint.url=http://localhost:8080
 elite2.api.uri.root=${elite2api.endpoint.url}/api
 oauth.endpoint.url=http://localhost:9090/auth

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ azure.application-insights.web.enable-W3C=true
 
 courts=Birmingham Immigration,Bromley,Caernarfon County,Caernarfon Crown,Caernarfon Magistrates,Cheltenham,City of London,Coventry Crown,Coventry Magistrates,Croydon Crown,Croydon Magistrates,Derby,Dudley,Hereford Crown,Hereford Magistrates,Inner London,Kidderminster,Kingston upon Thames,Leamington,Llandrindod Wells Justice Centre,Llandudno,Mold Crown,Mold County,Mold Magistrates,Prestatyn County,Redditch,Shrewsbury Crown,Shrewsbury Magistrates,South Derbyshire,Southwark,Telford,Thames,Walsall,Warwick,Welshpool County,Welshpool Magistrates,Westminster,Wimbledon,Wolverhampton Crown,Wolverhampton Magistrates,Wood Green,Woolwich,Worcester Crown,Worcester Magistrates,Wrexham County,Wrexham Magistrates
 
-courtIds=BIRAIT,BROMMC,CRNRCT,CRNRCC,CRNHMC,CHELMC,CITYMC,CVNTCC,CVNTMC,CRYDCC,CRYDMC,DRBYCC,DUDLMC,HERFCC,HERFMC,INNRCC,KIDDMC,KNGTCC,LEAMMC,LLNWMC,LLDUMC,MOLDCC,MOLDCT,MOLDMC,PRSTMC,RDDTMC,SHRWCC,SHREMC,DRBYMC,STHWCC,TELFMC,THMSMC,WALSMC,WRWKCC,WLSHCT,WLSHMC,CRT034,WMBLMC,WLVRCC,WLVRMC,WDGRCC,WOOLCC,WRCSCC,WRCSMC,WREXCT,WREXMC
+courtIds=BROMMC,CRNRCT,CRNRCC,CRNHMC,CHELMC,CITYMC,CVNTCC,CVNTMC,CRYDCC,CRYDMC,DRBYCC,DUDLMC,HERFCC,HERFMC,INNRCC,KIDDMC,KNGTCC,LEAMMC,LLNWMC,LLDUMC,MOLDCC,MOLDCT,MOLDMC,PRSTMC,RDDTMC,SHRWCC,SHREMC,DRBYMC,STHWCC,TELFMC,THMSMC,WALSMC,WRWKCC,WLSHCT,WLSHMC,CRT034,WMBLMC,WLVRCC,WLVRMC,WDGRCC,WOOLCC,WRCSCC,WRCSMC,WREXCT,WREXMC
 
 
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ azure.application-insights.web.enable-W3C=true
 
 courts=Birmingham Immigration,Bromley,Caernarfon County,Caernarfon Crown,Caernarfon Magistrates,Cheltenham,City of London,Coventry Crown,Coventry Magistrates,Croydon Crown,Croydon Magistrates,Derby,Dudley,Hereford Crown,Hereford Magistrates,Inner London,Kidderminster,Kingston upon Thames,Leamington,Llandrindod Wells Justice Centre,Llandudno,Mold Crown,Mold County,Mold Magistrates,Prestatyn County,Redditch,Shrewsbury Crown,Shrewsbury Magistrates,South Derbyshire,Southwark,Telford,Thames,Walsall,Warwick,Welshpool County,Welshpool Magistrates,Westminster,Wimbledon,Wolverhampton Crown,Wolverhampton Magistrates,Wood Green,Woolwich,Worcester Crown,Worcester Magistrates,Wrexham County,Wrexham Magistrates
 
-courtIds=BROMMC,CRNRCT,CRNRCC,CRNHMC,CHELMC,CITYMC,CVNTCC,CVNTMC,CRYDCC,CRYDMC,DRBYCC,DUDLMC,HERFCC,HERFMC,INNRCC,KIDDMC,KNGTCC,LEAMMC,LLNWMC,LLDUMC,MOLDCC,MOLDCT,MOLDMC,PRSTMC,RDDTMC,SHRWCC,SHREMC,DRBYMC,STHWCC,TELFMC,THMSMC,WALSMC,WRWKCC,WLSHCT,WLSHMC,CRT034,WMBLMC,WLVRCC,WLVRMC,WDGRCC,WOOLCC,WRCSCC,WRCSMC,WREXCT,WREXMC
+courtIds=BIRAIT,BROMMC,CRNRCT,CRNRCC,CRNHMC,CHELMC,CITYMC,CVNTCC,CVNTMC,CRYDCC,CRYDMC,DRBYCC,DUDLMC,HERFCC,HERFMC,INNRCC,KIDDMC,KNGTCC,LEAMMC,LLNWMC,LLDUMC,MOLDCC,MOLDCT,MOLDMC,PRSTMC,RDDTMC,SHRWCC,SHREMC,DRBYMC,STHWCC,TELFMC,THMSMC,WALSMC,WRWKCC,WLSHCT,WLSHMC,CRT034,WMBLMC,WLVRCC,WLVRMC,WDGRCC,WOOLCC,WRCSCC,WRCSMC,WREXCT,WREXMC
 
 
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/controllers/CourtControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/controllers/CourtControllerTest.kt
@@ -345,6 +345,52 @@ class CourtControllerTest : TestController() {
   }
 
   @Nested
+  inner class `Get court Ids` {
+
+    @Test
+    @WithMockUser(username = "ITAG_USER")
+    fun `return court Ids`() {
+
+      whenever(courtService.getCourtIds()).thenReturn(setOf("court_1", "court_2", "court_3"))
+
+      mockMvc.perform(
+        get("/court/courts")
+          .contentType(MediaType.APPLICATION_JSON)
+      )
+        .andExpect(
+          matchAll(
+            status().isOk,
+            content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON),
+            content().json("""{"courtIds":["court_1","court_2","court_3"]}""")
+          )
+        )
+    }
+  }
+
+  @Nested
+  inner class `Get no court Ids` {
+
+    @Test
+    @WithMockUser(username = "ITAG_USER")
+    fun `return court Ids`() {
+
+      whenever(courtService.getCourtIds()).thenReturn(setOf())
+
+      mockMvc.perform(
+        get("/court/courts")
+          .contentType(MediaType.APPLICATION_JSON)
+      )
+        .andExpect(
+          matchAll(
+            status().isOk,
+            content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON),
+            content().json("""{"courtIds":[]}""")
+          )
+        )
+    }
+  }
+
+  @Nested
   inner class `Update a Booking` {
     @Test
     @WithMockUser(username = "ITAG_USER")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/controllers/CourtControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/controllers/CourtControllerTest.kt
@@ -354,7 +354,7 @@ class CourtControllerTest : TestController() {
       whenever(courtService.getCourtIds()).thenReturn(setOf("court_1", "court_2", "court_3"))
 
       mockMvc.perform(
-        get("/court/courts")
+        get("/court/ids")
           .contentType(MediaType.APPLICATION_JSON)
       )
         .andExpect(
@@ -377,7 +377,7 @@ class CourtControllerTest : TestController() {
       whenever(courtService.getCourtIds()).thenReturn(setOf())
 
       mockMvc.perform(
-        get("/court/courts")
+        get("/court/ids")
           .contentType(MediaType.APPLICATION_JSON)
       )
         .andExpect(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/court/CourtServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/court/CourtServiceTest.kt
@@ -53,6 +53,28 @@ class CourtServiceTest {
   private val clock: Clock = Clock.fixed(Instant.parse("2020-10-01T00:00:00Z"), ZoneId.of("UTC"))
 
   @Test
+  fun `should return NO courtIds`() {
+    val service = service("", "")
+    val courtIds = service.getCourtIds()
+    assertThat(courtIds).isEqualTo(setOf(""))
+  }
+
+  @Test
+  fun `should return one courtId`() {
+    val service = service("", "courtId_1")
+    val courtIds = service.getCourtIds()
+    assertThat(courtIds).isEqualTo(setOf("courtId_1"))
+  }
+
+  @Test
+  fun `should return more than one courtId`() {
+    val service = service("", "courtId_1,courtId_2")
+    val courtIds = service.getCourtIds()
+    println(setOf("courtId_1", "courtId_2"))
+    assertThat(courtIds).isEqualTo(setOf("courtId_1", "courtId_2"))
+  }
+
+  @Test
   fun `should return NO video link appointments`() {
     val service = service("", "")
     val appointments = service.getVideoLinkAppointments(setOf(1, 2))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/court/CourtServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/court/CourtServiceTest.kt
@@ -54,7 +54,7 @@ class CourtServiceTest {
 
   @Test
   fun `should return NO video link appointments`() {
-    val service = service("")
+    val service = service("", "")
     val appointments = service.getVideoLinkAppointments(setOf(1, 2))
 
     verify(videoLinkAppointmentRepository).findVideoLinkAppointmentByAppointmentIdIn(setOf(1, 2))
@@ -76,7 +76,7 @@ class CourtServiceTest {
         )
       )
     )
-    val service = service("")
+    val service = service("", "")
     val appointments = service.getVideoLinkAppointments(setOf(3, 4))
 
     assertThat(appointments)
@@ -89,7 +89,7 @@ class CourtServiceTest {
 
   @Nested
   inner class CreateVideoLinkBooking {
-    val service = service("")
+    val service = service("", "")
 
     private val referenceTime = LocalDateTime
       .now(clock)
@@ -447,7 +447,7 @@ class CourtServiceTest {
 
     @Test
     fun `Happy flow - update main`() {
-      val service = service("")
+      val service = service("", "")
 
       val theBooking = VideoLinkBooking(
         id = 1L,
@@ -510,7 +510,7 @@ class CourtServiceTest {
      */
     @Test
     fun `Validation - main appointment start time in the past`() {
-      val service = service("")
+      val service = service("", "")
       assertThatThrownBy {
         service.updateVideoLinkBooking(
           1L,
@@ -530,7 +530,7 @@ class CourtServiceTest {
 
     @Test
     fun `Happy flow - update pre, main and post`() {
-      val service = service("")
+      val service = service("", "")
 
       val theBooking = VideoLinkBooking(
         id = 1L,
@@ -655,7 +655,7 @@ class CourtServiceTest {
 
   @Nested
   inner class DeleteVideoLinkBooking {
-    val service = service("")
+    val service = service("", "")
 
     private val mainAppointmentId = 12L
     private val mainVideoLinkAppointment = VideoLinkAppointment(
@@ -718,7 +718,7 @@ class CourtServiceTest {
 
   @Nested
   inner class GetVideoLinkBooking {
-    val service = service("")
+    val service = service("", "")
 
     private val mainAppointmentId = 12L
     private val mainVideoLinkAppointment = VideoLinkAppointment(
@@ -869,7 +869,7 @@ class CourtServiceTest {
 
   @Nested
   inner class GetVideoLinkBookingsForDateAndCourt {
-    val service = service("")
+    val service = service("", "")
     val date: LocalDate = LocalDate.of(2020, 12, 25)
 
     @Test
@@ -1093,7 +1093,7 @@ class CourtServiceTest {
 
     @Test
     fun `Happy flow - Pre, main and post appointments`() {
-      val service = service("")
+      val service = service("", "")
       val newComment = "New comment"
 
       whenever(videoLinkBookingRepository.findById(1L))
@@ -1136,7 +1136,7 @@ class CourtServiceTest {
 
     @Test
     fun `Happy flow - main appointment only, no comment`() {
-      val service = service("")
+      val service = service("", "")
       val newComment = ""
 
       whenever(videoLinkBookingRepository.findById(1L))
@@ -1162,13 +1162,14 @@ class CourtServiceTest {
     }
   }
 
-  private fun service(courts: String) = CourtService(
+  private fun service(courts: String, courtIds: String) = CourtService(
     prisonApiService,
     videoLinkAppointmentRepository,
     videoLinkBookingRepository,
     clock,
     videoLinkBookingEventListener,
-    courts
+    courts,
+    courtIds
   )
 
   companion object {


### PR DESCRIPTION
… ids
12/5/21: This is a draft PR because still need to determine courtId for Birmingham Immigration courts. 
Id to be added to line 8 of application.properties 

13/5/21. (1) BIRAIT immigration court now added. Just need to add test
13/5/21 (2) BIRAIT removed again until court-register is also returning immigration courts. PSH will not be able to lookup against BIRAIT without it also being returned by court-register. 