### PR TITLE
NN-3375: WIP 

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/controllers/AppointmentController.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/controllers/AppointmentController.kt
@@ -4,12 +4,18 @@ import io.swagger.annotations.Api
 import io.swagger.annotations.ApiOperation
 import io.swagger.annotations.ApiResponse
 import io.swagger.annotations.ApiResponses
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.whereabouts.dto.AppointmentCreatedDto
 import uk.gov.justice.digital.hmpps.whereabouts.dto.AppointmentDetailsDto
+import uk.gov.justice.digital.hmpps.whereabouts.dto.CreateAppointmentSpecification
 import uk.gov.justice.digital.hmpps.whereabouts.dto.ErrorResponse
 import uk.gov.justice.digital.hmpps.whereabouts.services.AppointmentService
 
@@ -30,15 +36,37 @@ class AppointmentController(private val appointmentService: AppointmentService) 
         code = 404,
         message = "Appointment not found.",
         response = ErrorResponse::class,
-        responseContainer = "List"
       ),
       ApiResponse(
         code = 500,
         message = "Unrecoverable error occurred whilst processing request.",
         response = ErrorResponse::class,
-        responseContainer = "List"
       )
     ]
   )
   fun getAppointment(@PathVariable("id") id: Long): AppointmentDetailsDto = appointmentService.getAppointment(id)
+
+  @PostMapping
+  @ResponseStatus(HttpStatus.CREATED)
+  @ApiOperation(
+    value = "Create an appointment",
+    nickname = "createAppointment"
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(code = 201, message = "CREATED", response = AppointmentCreatedDto::class),
+      ApiResponse(
+        code = 404,
+        message = "Appointment not found.",
+        response = ErrorResponse::class
+      ),
+      ApiResponse(
+        code = 500,
+        message = "Unrecoverable error occurred whilst processing request.",
+        response = ErrorResponse::class
+      )
+    ]
+  )
+  fun createAppointment(@RequestBody createAppointmentSpecification: CreateAppointmentSpecification): AppointmentCreatedDto =
+    appointmentService.createAppointment(createAppointmentSpecification)
 }

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/controllers/AppointmentController.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/controllers/AppointmentController.kt
@@ -56,8 +56,8 @@ class AppointmentController(private val appointmentService: AppointmentService) 
     value = [
       ApiResponse(code = 201, message = "CREATED", response = AppointmentCreatedDto::class),
       ApiResponse(
-        code = 404,
-        message = "Appointment not found.",
+        code = 400,
+        message = "Bad request",
         response = ErrorResponse::class
       ),
       ApiResponse(

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/dto/AppointmentDtos.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/dto/AppointmentDtos.kt
@@ -23,6 +23,15 @@ data class CreateBookingAppointment(
   val endTime: String
 )
 
+data class CreateAppointmentSpecification(
+  val bookingId: Long? = null,
+  val locationId: Long,
+  val appointmentType: String,
+  val comment: String? = null,
+  val startTime: LocalDateTime,
+  val endTime: LocalDateTime? = null
+)
+
 @ApiModel(description = "The data related to a single appointment.")
 data class AppointmentDto(
   @ApiModelProperty(required = true, value = "The event Id associated with this appointment")
@@ -102,4 +111,9 @@ data class AppointmentDetailsDto(
 data class Event(
   val eventId: Long,
   val agencyId: String,
+)
+
+data class AppointmentCreatedDto(
+  val mainAppointmentId: Long,
+  val recurringAppointments: Set<Long>? = null
 )

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/AppointmentService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/AppointmentService.kt
@@ -3,9 +3,12 @@ package uk.gov.justice.digital.hmpps.whereabouts.services
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.whereabouts.dto.AppointmentCreatedDto
 import uk.gov.justice.digital.hmpps.whereabouts.dto.AppointmentDetailsDto
 import uk.gov.justice.digital.hmpps.whereabouts.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.whereabouts.dto.AppointmentSearchDto
+import uk.gov.justice.digital.hmpps.whereabouts.dto.CreateAppointmentSpecification
+import uk.gov.justice.digital.hmpps.whereabouts.dto.CreateBookingAppointment
 import uk.gov.justice.digital.hmpps.whereabouts.dto.VideoLinkAppointmentDto
 import uk.gov.justice.digital.hmpps.whereabouts.dto.VideoLinkBookingDto
 import uk.gov.justice.digital.hmpps.whereabouts.dto.prisonapi.ScheduledAppointmentSearchDto
@@ -70,25 +73,44 @@ class AppointmentService(
     )
   }
 
+  fun createAppointment(createAppointmentSpecification: CreateAppointmentSpecification): AppointmentCreatedDto {
+    val event = prisonApiService.postAppointment(
+
+      createAppointmentSpecification.bookingId!!,
+      CreateBookingAppointment(
+        locationId = createAppointmentSpecification.locationId,
+        startTime = createAppointmentSpecification.startTime.toString(),
+        endTime = createAppointmentSpecification.endTime.toString(),
+        comment = createAppointmentSpecification.comment,
+        appointmentType = createAppointmentSpecification.appointmentType,
+      )
+    )
+
+    return AppointmentCreatedDto(
+      mainAppointmentId = event.eventId
+    )
+  }
+
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 }
 
-private fun makeAppointmentDto(scheduledAppointmentDto: ScheduledAppointmentSearchDto): AppointmentSearchDto = AppointmentSearchDto(
-  id = scheduledAppointmentDto.id,
-  agencyId = scheduledAppointmentDto.agencyId,
-  locationId = scheduledAppointmentDto.locationId,
-  locationDescription = scheduledAppointmentDto.locationDescription,
-  appointmentTypeCode = scheduledAppointmentDto.appointmentTypeCode,
-  appointmentTypeDescription = scheduledAppointmentDto.appointmentTypeDescription,
-  offenderNo = scheduledAppointmentDto.offenderNo,
-  firstName = scheduledAppointmentDto.firstName,
-  lastName = scheduledAppointmentDto.lastName,
-  startTime = scheduledAppointmentDto.startTime,
-  endTime = scheduledAppointmentDto.endTime,
-  createUserId = scheduledAppointmentDto.createUserId
-)
+private fun makeAppointmentDto(scheduledAppointmentDto: ScheduledAppointmentSearchDto): AppointmentSearchDto =
+  AppointmentSearchDto(
+    id = scheduledAppointmentDto.id,
+    agencyId = scheduledAppointmentDto.agencyId,
+    locationId = scheduledAppointmentDto.locationId,
+    locationDescription = scheduledAppointmentDto.locationDescription,
+    appointmentTypeCode = scheduledAppointmentDto.appointmentTypeCode,
+    appointmentTypeDescription = scheduledAppointmentDto.appointmentTypeDescription,
+    offenderNo = scheduledAppointmentDto.offenderNo,
+    firstName = scheduledAppointmentDto.firstName,
+    lastName = scheduledAppointmentDto.lastName,
+    startTime = scheduledAppointmentDto.startTime,
+    endTime = scheduledAppointmentDto.endTime,
+    createUserId = scheduledAppointmentDto.createUserId
+  )
 
 private fun makeAppointmentDto(offenderNo: String, prisonAppointment: PrisonAppointment): AppointmentDto =
   AppointmentDto(

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/AppointmentService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/AppointmentService.kt
@@ -75,7 +75,6 @@ class AppointmentService(
 
   fun createAppointment(createAppointmentSpecification: CreateAppointmentSpecification): AppointmentCreatedDto {
     val event = prisonApiService.postAppointment(
-
       createAppointmentSpecification.bookingId!!,
       CreateBookingAppointment(
         locationId = createAppointmentSpecification.locationId,

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/PrisonApiService.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/PrisonApiService.java
@@ -12,7 +12,6 @@ import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
-import uk.gov.justice.digital.hmpps.whereabouts.dto.AppointmentSearchDto;
 import uk.gov.justice.digital.hmpps.whereabouts.dto.BookingActivity;
 import uk.gov.justice.digital.hmpps.whereabouts.dto.CellMoveResult;
 import uk.gov.justice.digital.hmpps.whereabouts.dto.CreateBookingAppointment;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/controllers/AppointmentControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/controllers/AppointmentControllerTest.kt
@@ -7,11 +7,15 @@ import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.anyLong
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
 import org.springframework.security.test.context.support.WithMockUser
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-import org.springframework.test.web.servlet.result.MockMvcResultHandlers
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import uk.gov.justice.digital.hmpps.whereabouts.dto.CreateAppointmentSpecification
 import uk.gov.justice.digital.hmpps.whereabouts.services.AppointmentService
+import java.time.LocalDateTime
 import javax.persistence.EntityNotFoundException
 
 @WebMvcTest(AppointmentController::class)
@@ -26,9 +30,9 @@ class AppointmentControllerTest : TestController() {
     @Test
     @WithMockUser(username = "ITAG_USER")
     fun `should make a call to the appointments service to retrieve the appointment`() {
-      mockMvc.perform(MockMvcRequestBuilders.get("/appointment/$APPOINTMENT_ID"))
-        .andDo(MockMvcResultHandlers.print())
-        .andExpect(MockMvcResultMatchers.status().isOk)
+      mockMvc.perform(get("/appointment/$APPOINTMENT_ID"))
+        .andDo(print())
+        .andExpect(status().isOk)
 
       verify(appointmentService).getAppointment(APPOINTMENT_ID)
     }
@@ -38,9 +42,9 @@ class AppointmentControllerTest : TestController() {
     fun `should return a HTTP 404`() {
       whenever(appointmentService.getAppointment(anyLong())).thenThrow(EntityNotFoundException())
 
-      mockMvc.perform(MockMvcRequestBuilders.get("/appointment/$APPOINTMENT_ID"))
-        .andDo(MockMvcResultHandlers.print())
-        .andExpect(MockMvcResultMatchers.status().isNotFound)
+      mockMvc.perform(get("/appointment/$APPOINTMENT_ID"))
+        .andDo(print())
+        .andExpect(status().isNotFound)
     }
 
     @Test
@@ -48,9 +52,49 @@ class AppointmentControllerTest : TestController() {
     fun `should return a HTTP 500`() {
       whenever(appointmentService.getAppointment(anyLong())).thenThrow(NullPointerException())
 
-      mockMvc.perform(MockMvcRequestBuilders.get("/appointment/$APPOINTMENT_ID"))
-        .andDo(MockMvcResultHandlers.print())
-        .andExpect(MockMvcResultMatchers.status().is5xxServerError)
+      mockMvc.perform(get("/appointment/$APPOINTMENT_ID"))
+        .andDo(print())
+        .andExpect(status().is5xxServerError)
+    }
+  }
+
+  @Nested
+  inner class CreatingAnAppointment {
+    @Test
+    @WithMockUser(username = "ITAG_USER")
+    fun `should create an appointment`() {
+      val startTime = LocalDateTime.now()
+      val endTime = LocalDateTime.now()
+
+      mockMvc.perform(
+        post("/appointment")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(
+            objectMapper.writeValueAsString(
+              mapOf(
+                "locationId" to 1,
+                "startTime" to startTime,
+                "endTime" to endTime,
+                "bookingId" to 1,
+                "comment" to "test",
+                "appointmentType" to "ABC"
+              )
+            )
+          )
+      )
+        .andDo(print())
+        .andExpect(status().isCreated)
+
+      verify(appointmentService).createAppointment(
+        CreateAppointmentSpecification(
+          locationId = 1,
+          startTime = startTime,
+          endTime = endTime,
+          bookingId = 1,
+          comment = "test",
+          appointmentType = "ABC"
+        )
+      )
     }
   }
 


### PR DESCRIPTION
Add a new endpoint for appointment creation. At the moment all it does is ask prison API to create it. In later PR's were going to be storing information around recurring appointments.  