### PR TITLE
DCS-703 Refactor - remove redundancy from video_link_appointment, video_link_booking

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/dto/VideoLinkAppointmentsSpecification.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/dto/VideoLinkAppointmentsSpecification.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.whereabouts.dto
+
+interface VideoLinkAppointmentsSpecification {
+  val comment: String?
+  val pre: VideoLinkAppointmentSpecification?
+  val main: VideoLinkAppointmentSpecification
+  val post: VideoLinkAppointmentSpecification?
+}

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/dto/VideoLinkBookingSpecification.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/dto/VideoLinkBookingSpecification.kt
@@ -33,17 +33,17 @@ data class VideoLinkBookingSpecification(
   val madeByTheCourt: Boolean?,
 
   @ApiModelProperty(value = "Free text comments", example = "Requires special access")
-  val comment: String? = null,
+  override val comment: String? = null,
 
   @ApiModelProperty(value = "Pre-hearing appointment")
   @Valid
-  val pre: VideoLinkAppointmentSpecification? = null,
+  override val pre: VideoLinkAppointmentSpecification? = null,
 
   @ApiModelProperty(value = "Main appointment", required = true)
   @field:Valid
-  val main: VideoLinkAppointmentSpecification,
+  override val main: VideoLinkAppointmentSpecification,
 
   @ApiModelProperty(value = "Post-hearing appointment")
   @Valid
-  val post: VideoLinkAppointmentSpecification? = null
-)
+  override val post: VideoLinkAppointmentSpecification? = null
+) : VideoLinkAppointmentsSpecification

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/dto/VideoLinkBookingUpdateSpecification.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/dto/VideoLinkBookingUpdateSpecification.kt
@@ -6,17 +6,17 @@ import javax.validation.Valid
 data class VideoLinkBookingUpdateSpecification(
 
   @ApiModelProperty(value = "Free text comments", example = "Requires special access")
-  val comment: String? = null,
+  override val comment: String? = null,
 
   @ApiModelProperty(value = "Pre-hearing appointment")
   @Valid
-  val pre: VideoLinkAppointmentSpecification? = null,
+  override val pre: VideoLinkAppointmentSpecification? = null,
 
   @ApiModelProperty(value = "Main appointment", required = true)
   @field:Valid
-  val main: VideoLinkAppointmentSpecification,
+  override val main: VideoLinkAppointmentSpecification,
 
   @ApiModelProperty(value = "Post-hearing appointment")
   @Valid
-  val post: VideoLinkAppointmentSpecification? = null
-)
+  override val post: VideoLinkAppointmentSpecification? = null
+) : VideoLinkAppointmentsSpecification

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/model/VideoLinkAppointment.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/model/VideoLinkAppointment.kt
@@ -1,14 +1,13 @@
 package uk.gov.justice.digital.hmpps.whereabouts.model
 
-import org.springframework.data.annotation.CreatedBy
-import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import javax.persistence.Entity
-import javax.persistence.EntityListeners
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
 import javax.persistence.Table
 
 enum class HearingType {
@@ -19,21 +18,25 @@ enum class HearingType {
 
 @Entity
 @Table(name = "VIDEO_LINK_APPOINTMENT")
-@EntityListeners(AuditingEntityListener::class)
 data class VideoLinkAppointment(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  val id: Long? = null,
+  var id: Long? = null,
 
-  var bookingId: Long,
+  @ManyToOne
+  @JoinColumn(name = "video_link_booking_id")
+  var videoLinkBooking: VideoLinkBooking,
+
   var appointmentId: Long,
-  var court: String? = null,
-  var courtId: String? = null,
 
   @Enumerated(EnumType.STRING)
-  var hearingType: HearingType,
+  var hearingType: HearingType
+) {
+  override fun toString(): String = "VideoLinkAppointment(id = $id, appointmentId = $appointmentId, hearingType = $hearingType)"
 
-  @CreatedBy
-  var createdByUsername: String? = null,
-  var madeByTheCourt: Boolean? = true
-)
+  override fun equals(other: Any?): Boolean {
+    return other is VideoLinkAppointment && appointmentId == other.appointmentId
+  }
+
+  override fun hashCode(): Int = appointmentId.hashCode()
+}

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/model/VideoLinkBooking.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/model/VideoLinkBooking.kt
@@ -1,41 +1,85 @@
 package uk.gov.justice.digital.hmpps.whereabouts.model
 
-import javax.persistence.CascadeType.PERSIST
-import javax.persistence.CascadeType.REMOVE
+import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import uk.gov.justice.digital.hmpps.whereabouts.model.HearingType.MAIN
+import uk.gov.justice.digital.hmpps.whereabouts.model.HearingType.POST
+import uk.gov.justice.digital.hmpps.whereabouts.model.HearingType.PRE
+import javax.persistence.CascadeType
 import javax.persistence.Entity
+import javax.persistence.EntityListeners
+import javax.persistence.FetchType
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
-import javax.persistence.JoinColumn
-import javax.persistence.OneToOne
+import javax.persistence.MapKey
+import javax.persistence.OneToMany
 import javax.persistence.Table
 
 @Entity
 @Table(name = "VIDEO_LINK_BOOKING")
+@EntityListeners(AuditingEntityListener::class)
+/**
+ * Can use a data class here because VideoLinkBookings are never added to set like collections.
+ * Therefore the data class definition of equality is sufficient. (I hope!).
+ * Trying to implement a good equals function for this class is hard. There are different and conflicting requirements
+ * from Hibernate and tools like Mockito - Its doing my nut.
+ */
 data class VideoLinkBooking(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   var id: Long? = null,
 
-  @OneToOne(optional = false, orphanRemoval = true, cascade = [PERSIST, REMOVE])
-  @JoinColumn(name = "MAIN_APPOINTMENT")
-  var main: VideoLinkAppointment,
+  var offenderBookingId: Long,
+  var courtName: String? = null,
+  var courtId: String? = null,
+  var madeByTheCourt: Boolean? = true,
 
-  @OneToOne(optional = true, orphanRemoval = true, cascade = [PERSIST, REMOVE])
-  @JoinColumn(name = "PRE_APPOINTMENT")
-  var pre: VideoLinkAppointment? = null,
-
-  @OneToOne(optional = true, orphanRemoval = true, cascade = [PERSIST, REMOVE])
-  @JoinColumn(name = "POST_APPOINTMENT")
-  var post: VideoLinkAppointment? = null
+  @CreatedBy
+  var createdByUsername: String? = null,
 ) {
-  fun toAppointments(): List<VideoLinkAppointment> {
-    return listOfNotNull(pre, main, post)
-  }
+  @OneToMany(
+    mappedBy = "videoLinkBooking",
+    fetch = FetchType.EAGER,
+    cascade = [CascadeType.PERSIST, CascadeType.REMOVE, CascadeType.REFRESH],
+    orphanRemoval = true
+  )
+  @MapKey(name = "hearingType")
+  var appointments: MutableMap<HearingType, VideoLinkAppointment> = mutableMapOf()
+
+  fun addPreAppointment(appointmentId: Long, id: Long? = null) = appointments.put(
+    PRE,
+    VideoLinkAppointment(
+      id = id,
+      videoLinkBooking = this,
+      appointmentId = appointmentId,
+      hearingType = PRE
+    )
+  )
+
+  fun addMainAppointment(appointmentId: Long, id: Long? = null) = appointments.put(
+    MAIN,
+    VideoLinkAppointment(
+      id = id,
+      videoLinkBooking = this,
+      appointmentId = appointmentId,
+      hearingType = MAIN
+    )
+  )
+
+  fun addPostAppointment(appointmentId: Long, id: Long? = null) = appointments.put(
+    POST,
+    VideoLinkAppointment(
+      id = id,
+      videoLinkBooking = this,
+      appointmentId = appointmentId,
+      hearingType = POST
+    )
+  )
 
   fun matchesCourt(court: String?, courtId: String?): Boolean {
-    if (courtId != null) return main.courtId == courtId
-    if (court != null) return main.court == court
+    if (courtId != null) return courtId == this.courtId
+    if (court != null) return court == this.courtName
     return true
   }
 }

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/model/VideoLinkBooking.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/model/VideoLinkBooking.kt
@@ -35,7 +35,7 @@ data class VideoLinkBooking(
   @OneToMany(
     mappedBy = "videoLinkBooking",
     fetch = FetchType.EAGER,
-    cascade = [CascadeType.PERSIST, CascadeType.REMOVE, CascadeType.REFRESH],
+    cascade = [CascadeType.PERSIST, CascadeType.REMOVE],
     orphanRemoval = true
   )
   @MapKey(name = "hearingType")
@@ -71,9 +71,9 @@ data class VideoLinkBooking(
     )
   )
 
-  fun matchesCourt(court: String?, courtId: String?): Boolean {
+  fun matchesCourt(courtName: String?, courtId: String?): Boolean {
     if (courtId != null) return courtId == this.courtId
-    if (court != null) return court == this.courtName
+    if (courtName != null) return courtName == this.courtName
     return true
   }
 }

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/model/VideoLinkBooking.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/model/VideoLinkBooking.kt
@@ -70,10 +70,4 @@ data class VideoLinkBooking(
       hearingType = POST
     )
   )
-
-  fun matchesCourt(courtName: String?, courtId: String?): Boolean {
-    if (courtId != null) return courtId == this.courtId
-    if (courtName != null) return courtName == this.courtName
-    return true
-  }
 }

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/model/VideoLinkBooking.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/model/VideoLinkBooking.kt
@@ -19,12 +19,6 @@ import javax.persistence.Table
 @Entity
 @Table(name = "VIDEO_LINK_BOOKING")
 @EntityListeners(AuditingEntityListener::class)
-/**
- * Can use a data class here because VideoLinkBookings are never added to set like collections.
- * Therefore the data class definition of equality is sufficient. (I hope!).
- * Trying to implement a good equals function for this class is hard. There are different and conflicting requirements
- * from Hibernate and tools like Mockito - Its doing my nut.
- */
 data class VideoLinkBooking(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/repository/VideoLinkBookingRepository.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/repository/VideoLinkBookingRepository.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.whereabouts.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import uk.gov.justice.digital.hmpps.whereabouts.model.HearingType
 import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkBooking
 
@@ -14,12 +15,16 @@ interface VideoLinkBookingRepository : JpaRepository<VideoLinkBooking, Long> {
        where b.id in (
               select a.videoLinkBooking.id 
                from VideoLinkAppointment a
-              where a.appointmentId in ?1 and a.hearingType = ?2 
+              where a.appointmentId in :ids and a.hearingType = :hearingType 
              )
+             and (:courtName is null or b.courtName = :courtName)
+             and (:courtId is null   or b.courtId = :courtId)
           """
   )
   fun findByAppointmentIdsAndHearingType(
-    ids: List<Long>,
-    hearingType: HearingType = HearingType.MAIN
+    @Param("ids") ids: List<Long>,
+    @Param("hearingType") hearingType: HearingType = HearingType.MAIN,
+    @Param("courtName") courtName: String? = null,
+    @Param("courtId") courtId: String? = null
   ): List<VideoLinkBooking>
 }

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/repository/VideoLinkBookingRepository.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/repository/VideoLinkBookingRepository.kt
@@ -2,15 +2,16 @@ package uk.gov.justice.digital.hmpps.whereabouts.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import uk.gov.justice.digital.hmpps.whereabouts.model.HearingType
 import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkBooking
 
 interface VideoLinkBookingRepository : JpaRepository<VideoLinkBooking, Long> {
   @Query(
     """
       select b
-        from VideoLinkBooking b
-       where b.main.appointmentId in ?1
+        from VideoLinkBooking b join b.appointments a
+       where a.appointmentId in ?1 and a.hearingType = ?2
     """
   )
-  fun findByMainAppointmentIds(ids: List<Long>): List<VideoLinkBooking>
+  fun findByAppointmentIdsAndHearingType(ids: List<Long>, hearingType: HearingType = HearingType.MAIN): List<VideoLinkBooking>
 }

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/repository/VideoLinkBookingRepository.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/repository/VideoLinkBookingRepository.kt
@@ -8,10 +8,18 @@ import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkBooking
 interface VideoLinkBookingRepository : JpaRepository<VideoLinkBooking, Long> {
   @Query(
     """
-      select b
-        from VideoLinkBooking b join b.appointments a
-       where a.appointmentId in ?1 and a.hearingType = ?2
-    """
+      select distinct b
+        from VideoLinkBooking b 
+             left outer join fetch b.appointments
+       where b.id in (
+              select a.videoLinkBooking.id 
+               from VideoLinkAppointment a
+              where a.appointmentId in ?1 and a.hearingType = ?2 
+             )
+          """
   )
-  fun findByAppointmentIdsAndHearingType(ids: List<Long>, hearingType: HearingType = HearingType.MAIN): List<VideoLinkBooking>
+  fun findByAppointmentIdsAndHearingType(
+    ids: List<Long>,
+    hearingType: HearingType = HearingType.MAIN
+  ): List<VideoLinkBooking>
 }

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/ApplicationInsightsEventListener.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/ApplicationInsightsEventListener.kt
@@ -5,6 +5,9 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.whereabouts.dto.VideoLinkAppointmentSpecification
 import uk.gov.justice.digital.hmpps.whereabouts.dto.VideoLinkBookingSpecification
 import uk.gov.justice.digital.hmpps.whereabouts.dto.VideoLinkBookingUpdateSpecification
+import uk.gov.justice.digital.hmpps.whereabouts.model.HearingType.MAIN
+import uk.gov.justice.digital.hmpps.whereabouts.model.HearingType.POST
+import uk.gov.justice.digital.hmpps.whereabouts.model.HearingType.PRE
 import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkAppointment
 import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkBooking
 import uk.gov.justice.digital.hmpps.whereabouts.security.AuthenticationFacade
@@ -14,19 +17,23 @@ class ApplicationInsightsEventListener(
   private val authenticationFacade: AuthenticationFacade,
   private val telemetryClient: TelemetryClient,
 ) : VideoLinkBookingEventListener {
-  override fun bookingCreated(booking: VideoLinkBooking, specification: VideoLinkBookingSpecification, agencyId: String) {
+  override fun bookingCreated(
+    booking: VideoLinkBooking,
+    specification: VideoLinkBookingSpecification,
+    agencyId: String
+  ) {
     val properties = mutableMapOf(
       "id" to (booking.id?.toString()),
-      "bookingId" to booking.main.bookingId.toString(),
+      "bookingId" to booking.offenderBookingId.toString(),
       "court" to specification.court,
       "user" to authenticationFacade.currentUsername,
       "agencyId" to agencyId,
       "madeByTheCourt" to specification.madeByTheCourt.toString(),
     )
 
-    properties.putAll(appointmentDetail(booking.main, specification.main))
-    booking.pre?.also { properties.putAll(appointmentDetail(it, specification.pre!!)) }
-    booking.post?.also { properties.putAll(appointmentDetail(it, specification.post!!)) }
+    booking.appointments[MAIN]?.also { properties.putAll(appointmentDetail(it, specification.main)) }
+    booking.appointments[PRE]?.also { properties.putAll(appointmentDetail(it, specification.pre!!)) }
+    booking.appointments[POST]?.also { properties.putAll(appointmentDetail(it, specification.post!!)) }
 
     telemetryClient.trackEvent("VideoLinkBookingCreated", properties, null)
   }
@@ -34,14 +41,14 @@ class ApplicationInsightsEventListener(
   override fun bookingUpdated(booking: VideoLinkBooking, specification: VideoLinkBookingUpdateSpecification) {
     val properties = mutableMapOf(
       "id" to (booking.id?.toString()),
-      "bookingId" to booking.main.bookingId.toString(),
-      "court" to booking.main.court,
+      "bookingId" to booking.offenderBookingId.toString(),
+      "court" to booking.courtName,
       "user" to authenticationFacade.currentUsername,
     )
 
-    properties.putAll(appointmentDetail(booking.main, specification.main))
-    booking.pre?.also { properties.putAll(appointmentDetail(it, specification.pre!!)) }
-    booking.post?.also { properties.putAll(appointmentDetail(it, specification.post!!)) }
+    booking.appointments[MAIN]?.also { properties.putAll(appointmentDetail(it, specification.main)) }
+    booking.appointments[PRE]?.also { properties.putAll(appointmentDetail(it, specification.pre!!)) }
+    booking.appointments[POST]?.also { properties.putAll(appointmentDetail(it, specification.post!!)) }
 
     telemetryClient.trackEvent("VideoLinkBookingUpdated", properties, null)
   }
@@ -53,14 +60,12 @@ class ApplicationInsightsEventListener(
   private fun telemetryProperties(booking: VideoLinkBooking): MutableMap<String, String?> {
     val properties = mutableMapOf(
       "id" to (booking.id?.toString()),
-      "bookingId" to booking.main.bookingId.toString(),
-      "court" to booking.main.court,
+      "bookingId" to booking.offenderBookingId.toString(),
+      "court" to booking.courtName,
       "user" to authenticationFacade.currentUsername,
     )
 
-    properties.putAll(appointmentDetail(booking.main))
-    booking.pre?.also { properties.putAll(appointmentDetail(it)) }
-    booking.post?.also { properties.putAll(appointmentDetail(it)) }
+    booking.appointments.values.forEach { properties.putAll(appointmentDetail(it)) }
     return properties
   }
 

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/CourtService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/CourtService.kt
@@ -19,10 +19,10 @@ class CourtService(private val courtRepository: CourtRepository) {
   private val idToNameMap: Map<String, String> by lazy { courts.associate { it.id to it.name } }
   private val nameToIdMap: Map<String, String> by lazy { courts.associate { it.name.lowercase() to it.id } }
 
-  fun findName(courtId: String): String? = idToNameMap[courtId]
-  fun findId(courtName: String): String? = nameToIdMap[courtName.trim().lowercase()]
+  fun getCourtNameForCourtId(courtId: String): String? = idToNameMap[courtId]
+  fun getCourtIdForCourtName(courtName: String): String? = nameToIdMap[courtName.trim().lowercase()]
 
   fun chooseCourtName(booking: VideoLinkBooking): String {
-    return booking.courtId?.let { findName(it) } ?: booking.courtName ?: UNKNOWN_COURT_NAME
+    return booking.courtId?.let { getCourtNameForCourtId(it) } ?: booking.courtName ?: UNKNOWN_COURT_NAME
   }
 }

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/CourtService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/CourtService.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.whereabouts.services.court
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.whereabouts.model.Court
-import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkAppointment
+import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkBooking
 import uk.gov.justice.digital.hmpps.whereabouts.repository.CourtRepository
 
 const val UNKNOWN_COURT_NAME = "Unknown"
@@ -22,9 +22,7 @@ class CourtService(private val courtRepository: CourtRepository) {
   fun findName(courtId: String): String? = idToNameMap[courtId]
   fun findId(courtName: String): String? = nameToIdMap[courtName.trim().lowercase()]
 
-  fun chooseCourtName(appointment: VideoLinkAppointment): String {
-    val courtName = appointment.courtId?.let { findName(it) } ?: appointment.court ?: UNKNOWN_COURT_NAME
-    println("CourtService.chooseCourtName: appointment $appointment. Found courtName $courtName")
-    return courtName
+  fun chooseCourtName(booking: VideoLinkBooking): String {
+    return booking.courtId?.let { findName(it) } ?: booking.courtName ?: UNKNOWN_COURT_NAME
   }
 }

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/EventStoreListener.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/EventStoreListener.kt
@@ -3,6 +3,9 @@ package uk.gov.justice.digital.hmpps.whereabouts.services.court
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.whereabouts.dto.VideoLinkBookingSpecification
 import uk.gov.justice.digital.hmpps.whereabouts.dto.VideoLinkBookingUpdateSpecification
+import uk.gov.justice.digital.hmpps.whereabouts.model.HearingType.MAIN
+import uk.gov.justice.digital.hmpps.whereabouts.model.HearingType.POST
+import uk.gov.justice.digital.hmpps.whereabouts.model.HearingType.PRE
 import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkBooking
 import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkBookingEvent
 import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkBookingEventType
@@ -29,16 +32,16 @@ class EventStoreListener(
         comment = specification.comment,
         offenderBookingId = specification.bookingId,
         madeByTheCourt = specification.madeByTheCourt,
-        mainNomisAppointmentId = booking.main.appointmentId,
+        mainNomisAppointmentId = booking.appointments[MAIN]?.appointmentId,
         mainLocationId = specification.main.locationId,
         mainStartTime = specification.main.startTime,
         mainEndTime = specification.main.endTime,
-        preNomisAppointmentId = booking.pre?.appointmentId,
+        preNomisAppointmentId = booking.appointments[PRE]?.appointmentId,
         preLocationId = specification.pre?.locationId,
         preStartTime = specification.pre?.startTime,
         preEndTime = specification.pre?.endTime,
         postLocationId = specification.post?.locationId,
-        postNomisAppointmentId = booking.post?.appointmentId,
+        postNomisAppointmentId = booking.appointments[POST]?.appointmentId,
         postStartTime = specification.post?.startTime,
         postEndTime = specification.post?.endTime
       )
@@ -53,16 +56,16 @@ class EventStoreListener(
         userId = authenticationFacade.currentUsername,
         videoLinkBookingId = booking.id!!,
         comment = specification.comment,
-        mainNomisAppointmentId = booking.main.appointmentId,
+        mainNomisAppointmentId = booking.appointments[MAIN]?.appointmentId,
         mainLocationId = specification.main.locationId,
         mainStartTime = specification.main.startTime,
         mainEndTime = specification.main.endTime,
-        preNomisAppointmentId = booking.pre?.appointmentId,
+        preNomisAppointmentId = booking.appointments[PRE]?.appointmentId,
         preLocationId = specification.pre?.locationId,
         preStartTime = specification.pre?.startTime,
         preEndTime = specification.pre?.endTime,
         postLocationId = specification.post?.locationId,
-        postNomisAppointmentId = booking.post?.appointmentId,
+        postNomisAppointmentId = booking.appointments[POST]?.appointmentId,
         postStartTime = specification.post?.startTime,
         postEndTime = specification.post?.endTime
       )

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/VideoLinkBookingService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/VideoLinkBookingService.kt
@@ -207,25 +207,28 @@ class VideoLinkBookingService(
     val scheduledAppointmentIds = scheduledAppointments.map { it.id }
 
     // If a booking's main appointment doesn't match one of the scheduledAppointmentIds then it is excluded
-    val bookings = videoLinkBookingRepository.findByAppointmentIdsAndHearingType(scheduledAppointmentIds, MAIN)
+    val bookings = videoLinkBookingRepository.findByAppointmentIdsAndHearingType(
+      ids = scheduledAppointmentIds,
+      courtName = courtName,
+      courtId = courtId,
+      hearingType = MAIN
+    )
 
     val scheduledAppointmentsById = scheduledAppointments.associateBy { it.id }
 
-    return bookings
-      .filter { it.matchesCourt(courtName, courtId) }
-      .map {
-        val mainPrisonAppointment = scheduledAppointmentsById[it.appointments[MAIN]?.appointmentId]!!
-        VideoLinkBookingResponse(
-          videoLinkBookingId = it.id!!,
-          bookingId = it.offenderBookingId,
-          agencyId = mainPrisonAppointment.agencyId,
-          court = courtService.chooseCourtName(it),
-          courtId = it.courtId,
-          main = toVideoLinkAppointmentDto(mainPrisonAppointment)!!,
-          pre = toVideoLinkAppointmentDto(scheduledAppointmentsById[it.appointments[PRE]?.appointmentId]),
-          post = toVideoLinkAppointmentDto(scheduledAppointmentsById[it.appointments[POST]?.appointmentId])
-        )
-      }
+    return bookings.map {
+      val mainPrisonAppointment = scheduledAppointmentsById[it.appointments[MAIN]?.appointmentId]!!
+      VideoLinkBookingResponse(
+        videoLinkBookingId = it.id!!,
+        bookingId = it.offenderBookingId,
+        agencyId = mainPrisonAppointment.agencyId,
+        court = courtService.chooseCourtName(it),
+        courtId = it.courtId,
+        main = toVideoLinkAppointmentDto(mainPrisonAppointment)!!,
+        pre = toVideoLinkAppointmentDto(scheduledAppointmentsById[it.appointments[PRE]?.appointmentId]),
+        post = toVideoLinkAppointmentDto(scheduledAppointmentsById[it.appointments[POST]?.appointmentId])
+      )
+    }
   }
 
   fun updateVideoLinkBookingComment(videoLinkBookingId: Long, comment: String?) {

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/locationfinder/AppointmentLocationsService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/locationfinder/AppointmentLocationsService.kt
@@ -32,7 +32,7 @@ class AppointmentLocationsService(
     else
       videoLinkBookingRepository
         .findAllById(vlbIdsToExclude)
-        .flatMap { booking -> booking.toAppointments().map { it.appointmentId } }
+        .flatMap { booking -> booking.appointments.values.map { it.appointmentId } }
         .toSet()
 
   private fun fetchVideoLinkBookingLocations(specification: AppointmentLocationsSpecification) =

--- a/src/main/resources/db/migration/V24__normalise_video_link_booking.sql
+++ b/src/main/resources/db/migration/V24__normalise_video_link_booking.sql
@@ -1,0 +1,83 @@
+create table video_link_appointment_pre_dcs_703 as table video_link_appointment;
+create table video_link_booking_pre_dcs_703 as table video_link_booking;
+
+alter table video_link_booking
+    add column offender_booking_id bigint;
+
+alter table video_link_booking
+    add column court_name varchar(50);
+
+alter table video_link_booking
+    add column court_id varchar(50);
+
+alter table video_link_booking
+    add column made_by_the_court boolean;
+
+alter table video_link_booking
+    add column created_by_username varchar(50);
+
+alter table video_link_appointment
+    add column video_link_booking_id integer;
+
+update video_link_booking b
+set (offender_booking_id, court_name, court_id, made_by_the_court, created_by_username) = (
+    select booking_id, court, court_id, made_by_the_court, created_by_username
+    from video_link_appointment a
+    where b.main_appointment = a.id
+);
+
+alter table video_link_appointment
+    drop column booking_id;
+
+alter table video_link_appointment
+    drop column court;
+
+alter table video_link_appointment
+    drop column court_id;
+
+alter table video_link_appointment
+    drop column made_by_the_court;
+
+alter table video_link_appointment
+    drop column created_by_username;
+
+alter table video_link_booking
+    alter column offender_booking_id set not null;
+
+alter table video_link_booking
+    alter column made_by_the_court set default true;
+
+alter table video_link_booking
+    alter column made_by_the_court set not null;
+
+update video_link_appointment a
+set video_link_booking_id = (select id from video_link_booking b where b.main_appointment = a.id)
+where hearing_type = 'MAIN';
+
+update video_link_appointment a
+set video_link_booking_id = (select id from video_link_booking b where b.pre_appointment = a.id)
+where hearing_type = 'PRE';
+
+update video_link_appointment a
+set video_link_booking_id = (select id from video_link_booking b where b.post_appointment = a.id)
+where hearing_type = 'POST';
+
+delete from video_link_appointment where video_link_booking_id is null;
+
+alter table video_link_appointment
+    alter column video_link_booking_id set not null;
+
+alter table video_link_appointment
+    add constraint video_link_appointment_fk foreign key (video_link_booking_id) references video_link_booking(id);
+
+alter table video_link_booking
+    drop column main_appointment;
+
+alter table video_link_booking
+    drop column pre_appointment;
+
+alter table video_link_booking
+    drop column post_appointment;
+
+alter table video_link_appointment
+    add constraint video_link_appointment_unique unique (video_link_booking_id, hearing_type);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/integration/AppointmentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/integration/AppointmentIntegrationTest.kt
@@ -5,6 +5,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
 import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.isA
 import com.nhaarman.mockitokotlin2.whenever
 import org.junit.jupiter.api.BeforeEach
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.data.domain.Sort
+import uk.gov.justice.digital.hmpps.whereabouts.model.HearingType
 import uk.gov.justice.digital.hmpps.whereabouts.model.RecurringAppointment
 import uk.gov.justice.digital.hmpps.whereabouts.model.RelatedAppointment
 import uk.gov.justice.digital.hmpps.whereabouts.model.RepeatPeriod
@@ -72,7 +74,7 @@ class AppointmentIntegrationTest : IntegrationTest() {
 
     @Test
     fun `should return video link booking details`() {
-      whenever(videoLinkBookingRepository.findByMainAppointmentIds(any()))
+      whenever(videoLinkBookingRepository.findByAppointmentIdsAndHearingType(any(), eq(HearingType.MAIN)))
         .thenReturn(listOf(DataHelpers.makeVideoLinkBooking(id = 1)))
 
       webTestClient.mutate().responseTimeout(Duration.ofSeconds(10)).build().get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/integration/AppointmentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/integration/AppointmentIntegrationTest.kt
@@ -7,6 +7,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.isA
+import com.nhaarman.mockitokotlin2.isNull
 import com.nhaarman.mockitokotlin2.whenever
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -74,7 +75,7 @@ class AppointmentIntegrationTest : IntegrationTest() {
 
     @Test
     fun `should return video link booking details`() {
-      whenever(videoLinkBookingRepository.findByAppointmentIdsAndHearingType(any(), eq(HearingType.MAIN)))
+      whenever(videoLinkBookingRepository.findByAppointmentIdsAndHearingType(any(), eq(HearingType.MAIN), isNull(), isNull()))
         .thenReturn(listOf(DataHelpers.makeVideoLinkBooking(id = 1)))
 
       webTestClient.mutate().responseTimeout(Duration.ofSeconds(10)).build().get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/integration/CourtIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/integration/CourtIntegrationTest.kt
@@ -2,31 +2,27 @@ package uk.gov.justice.digital.hmpps.whereabouts.integration
 
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.microsoft.applicationinsights.TelemetryClient
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType
-import uk.gov.justice.digital.hmpps.whereabouts.model.HearingType
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.jdbc.JdbcTestUtils
+import uk.gov.justice.digital.hmpps.whereabouts.model.HearingType.MAIN
 import uk.gov.justice.digital.hmpps.whereabouts.model.PrisonAppointment
-import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkAppointment
 import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkBooking
-import uk.gov.justice.digital.hmpps.whereabouts.repository.VideoLinkAppointmentRepository
 import uk.gov.justice.digital.hmpps.whereabouts.repository.VideoLinkBookingRepository
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME
 import java.time.temporal.ChronoUnit
-import java.util.Optional
 
-class CourtIntegrationTest : IntegrationTest() {
-
-  @MockBean
-  lateinit var videoLinkAppointmentRepository: VideoLinkAppointmentRepository
-
-  @MockBean
-  lateinit var videoLinkBookingRepository: VideoLinkBookingRepository
+class CourtIntegrationTest(
+  @Autowired val videoLinkBookingRepository: VideoLinkBookingRepository,
+  @Autowired val jdbcTemplate: JdbcTemplate,
+) : IntegrationTest() {
 
   @MockBean
   lateinit var telemetryClient: TelemetryClient
@@ -62,14 +58,13 @@ class CourtIntegrationTest : IntegrationTest() {
   }
 
   @Nested
-  inner class GetAppointment {
+  inner class GetBooking {
 
-    val videoBookingId: Long = 1
     val preAppointmentId: Long = 2
     val mainAppointmentId: Long = 3
     val postAppointmentId: Long = 4
 
-    val preAppointment = PrisonAppointment(
+    val prePrisonAppointment = PrisonAppointment(
       bookingId = 100,
       eventId = preAppointmentId,
       startTime = referenceTime,
@@ -80,7 +75,7 @@ class CourtIntegrationTest : IntegrationTest() {
       comment = "any comment"
     )
 
-    val mainAppointment = PrisonAppointment(
+    val mainPrisonAppointment = PrisonAppointment(
       bookingId = 100,
       eventId = mainAppointmentId,
       startTime = referenceTime.plusMinutes(30),
@@ -91,7 +86,7 @@ class CourtIntegrationTest : IntegrationTest() {
       comment = "any comment",
     )
 
-    val postAppointment = PrisonAppointment(
+    val postPrisonAppointment = PrisonAppointment(
       bookingId = 100,
       eventId = postAppointmentId,
       startTime = referenceTime.plusMinutes(60),
@@ -102,45 +97,41 @@ class CourtIntegrationTest : IntegrationTest() {
       comment = "any comment"
     )
 
-    val theVideoLinkBooking = VideoLinkBooking(
-      id = videoBookingId,
-      pre = VideoLinkAppointment(
-        id = 10,
-        bookingId = 100,
-        appointmentId = preAppointmentId,
-        court = "Test Court 1",
-        courtId = "TSTCRT1",
-        hearingType = HearingType.PRE
-      ),
-      main = VideoLinkAppointment(
-        id = 11,
-        bookingId = 100,
-        appointmentId = mainAppointmentId,
-        court = "Test Court 2",
-        courtId = "TSTCRT2",
-        hearingType = HearingType.MAIN
-      ),
-      post = VideoLinkAppointment(
-        id = 12,
-        bookingId = 100,
-        appointmentId = postAppointmentId,
-        court = "Test Court 1",
-        courtId = "TSTCRT1",
-        hearingType = HearingType.POST
-      ),
-    )
+    fun makeVideoLinkBooking() = VideoLinkBooking(
+      offenderBookingId = 100,
+      courtName = "Test Court 1",
+      courtId = "TSTCRT1"
+    ).apply {
+      addPreAppointment(appointmentId = preAppointmentId)
+      addMainAppointment(appointmentId = mainAppointmentId)
+      addPostAppointment(appointmentId = postAppointmentId)
+    }
+
+    @BeforeEach
+    fun resetVideoLinkBookings() {
+      JdbcTestUtils.deleteFromTables(jdbcTemplate, "VIDEO_LINK_APPOINTMENT", "VIDEO_LINK_BOOKING")
+    }
 
     @Test
     fun `should get booking`() {
 
-      whenever(videoLinkBookingRepository.findById(videoBookingId)).thenReturn(Optional.of(theVideoLinkBooking))
+      val videoLinkBookingId = videoLinkBookingRepository.save(makeVideoLinkBooking()).id!!
 
-      prisonApiMockServer.stubGetPrisonAppointment(preAppointmentId, objectMapper.writeValueAsString(preAppointment))
-      prisonApiMockServer.stubGetPrisonAppointment(mainAppointmentId, objectMapper.writeValueAsString(mainAppointment))
-      prisonApiMockServer.stubGetPrisonAppointment(postAppointmentId, objectMapper.writeValueAsString(postAppointment))
+      prisonApiMockServer.stubGetPrisonAppointment(
+        preAppointmentId,
+        objectMapper.writeValueAsString(prePrisonAppointment)
+      )
+      prisonApiMockServer.stubGetPrisonAppointment(
+        mainAppointmentId,
+        objectMapper.writeValueAsString(mainPrisonAppointment)
+      )
+      prisonApiMockServer.stubGetPrisonAppointment(
+        postAppointmentId,
+        objectMapper.writeValueAsString(postPrisonAppointment)
+      )
 
       webTestClient.get()
-        .uri("/court/video-link-bookings/$videoBookingId")
+        .uri("/court/video-link-bookings/$videoLinkBookingId")
         .headers(setHeaders())
         .exchange()
         .expectStatus().isOk
@@ -148,11 +139,11 @@ class CourtIntegrationTest : IntegrationTest() {
         .json(
           """
           {
-            "videoLinkBookingId": 1,
+            "videoLinkBookingId": $videoLinkBookingId,
             "bookingId": 100,
             "agencyId" : "WWI",
-            "court": "Test Court 2",
-            "courtId": "TSTCRT2",
+            "court": "Test Court 1",
+            "courtId": "TSTCRT1",
             "comment": "any comment",
             "pre": {
               "locationId": 10,
@@ -177,12 +168,15 @@ class CourtIntegrationTest : IntegrationTest() {
     @Test
     fun `should get booking when only main appointment exists`() {
 
-      whenever(videoLinkBookingRepository.findById(videoBookingId)).thenReturn(Optional.of(theVideoLinkBooking))
+      val videoLinkBookingId = videoLinkBookingRepository.save(makeVideoLinkBooking()).id!!
 
-      prisonApiMockServer.stubGetPrisonAppointment(mainAppointmentId, objectMapper.writeValueAsString(mainAppointment))
+      prisonApiMockServer.stubGetPrisonAppointment(
+        mainAppointmentId,
+        objectMapper.writeValueAsString(mainPrisonAppointment)
+      )
 
       webTestClient.get()
-        .uri("/court/video-link-bookings/$videoBookingId")
+        .uri("/court/video-link-bookings/$videoLinkBookingId")
         .headers(setHeaders())
         .exchange()
         .expectStatus().isOk
@@ -190,11 +184,11 @@ class CourtIntegrationTest : IntegrationTest() {
         .json(
           """
           {
-            "videoLinkBookingId": 1,
+            "videoLinkBookingId": $videoLinkBookingId,
             "bookingId": 100,
             "agencyId": "WWI",
-            "court": "Test Court 2",
-            "courtId": "TSTCRT2",
+            "court": "Test Court 1",
+            "courtId": "TSTCRT1",
             "comment": "any comment",
             "main": {
               "locationId": 9,
@@ -209,189 +203,218 @@ class CourtIntegrationTest : IntegrationTest() {
     @Test
     fun `should not find booking when only pre and post appointments exist`() {
 
-      whenever(videoLinkBookingRepository.findById(videoBookingId)).thenReturn(Optional.of(theVideoLinkBooking))
+      val videoLinkBookingId = videoLinkBookingRepository.save(makeVideoLinkBooking()).id!!
 
-      prisonApiMockServer.stubGetPrisonAppointment(preAppointmentId, objectMapper.writeValueAsString(preAppointment))
-      prisonApiMockServer.stubGetPrisonAppointment(postAppointmentId, objectMapper.writeValueAsString(postAppointment))
+      prisonApiMockServer.stubGetPrisonAppointment(
+        preAppointmentId,
+        objectMapper.writeValueAsString(prePrisonAppointment)
+      )
+      prisonApiMockServer.stubGetPrisonAppointment(
+        postAppointmentId,
+        objectMapper.writeValueAsString(postPrisonAppointment)
+      )
 
       webTestClient.get()
-        .uri("/court/video-link-bookings/$videoBookingId")
+        .uri("/court/video-link-bookings/$videoLinkBookingId")
         .headers(setHeaders())
         .exchange()
         .expectStatus().isNotFound
     }
   }
 
-  @Test
-  fun `should return video link appointment by appointment id`() {
-    whenever(videoLinkAppointmentRepository.findVideoLinkAppointmentByAppointmentIdIn(setOf(1L)))
-      .thenReturn(
-        setOf(
-          VideoLinkAppointment(
-            id = 1L,
-            bookingId = 1L,
-            appointmentId = 1L,
-            hearingType = HearingType.PRE,
-            court = "York",
-            courtId = "TSTCRT"
-          )
-        )
+  @Nested
+  inner class GetAppointments {
+    @BeforeEach
+    fun resetVideoLinkBookings() {
+      JdbcTestUtils.deleteFromTables(jdbcTemplate, "VIDEO_LINK_APPOINTMENT", "VIDEO_LINK_BOOKING")
+    }
+
+    @Test
+    fun `should return video link appointment by appointment id`() {
+      val persistentBooking = videoLinkBookingRepository.save(
+        VideoLinkBooking(
+          offenderBookingId = 1L,
+          courtName = "York",
+          courtId = "TSTCRT"
+        ).apply { addMainAppointment(appointmentId = 1L) }
       )
 
-    webTestClient.post()
-      .uri("/court/video-link-appointments")
-      .headers(setHeaders())
-      .bodyValue(setOf(1L))
-      .exchange()
-      .expectStatus().isOk
-      .expectBody()
-      .json(
-        """
+      val mainAppointmentId = persistentBooking.appointments[MAIN]?.id
+      assertThat(mainAppointmentId).isNotNull
+
+      webTestClient.post()
+        .uri("/court/video-link-appointments")
+        .headers(setHeaders())
+        .bodyValue(setOf(1L))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .json(
+          """
           {
             "appointments": [
               {
-                "id": 1,
+                "id": $mainAppointmentId,
                 "bookingId": 1,
                 "appointmentId": 1,
                 "court": "York",
                 "courtId": "TSTCRT",
-                "hearingType": "PRE"
+                "hearingType": "MAIN"
               }
             ]
           }
       """
-      )
+        )
+    }
   }
 
-  @Test
-  fun `Successful POST video-link-bookings, main appointment only`() {
-    val bookingId = 1L
-    val mainAppointmentId = 1L
+  @Nested
+  inner class CreateBooking {
+    @BeforeEach
+    fun resetVideoLinkBookings() {
+      JdbcTestUtils.deleteFromTables(jdbcTemplate, "VIDEO_LINK_APPOINTMENT", "VIDEO_LINK_BOOKING")
+    }
 
-    prisonApiMockServer.stubGetLocation(1L)
-    prisonApiMockServer.stubAddAppointmentForBooking(bookingId, eventId = mainAppointmentId)
+    @Test
+    fun `Successful POST video-link-bookings, main appointment only`() {
+      val bookingId = 1L
+      val mainAppointmentId = 1L
 
-    val theVideoLinkBooking = VideoLinkBooking(
-      main = VideoLinkAppointment(
-        bookingId = bookingId,
-        appointmentId = mainAppointmentId,
-        court = "Test Court 1",
-        courtId = "TSTCRT",
-        madeByTheCourt = false,
-        hearingType = HearingType.MAIN
-      )
-    )
+      prisonApiMockServer.stubGetLocation(1L)
+      prisonApiMockServer.stubAddAppointmentForBooking(bookingId, eventId = mainAppointmentId)
 
-    whenever(videoLinkBookingRepository.save(any())).thenReturn(theVideoLinkBooking.copy(id = 1))
-
-    webTestClient.post()
-      .uri("/court/video-link-bookings")
-      .headers(setHeaders())
-      .bodyValue(
-        mapOf(
-          "bookingId" to bookingId,
-          "court" to "Test Court 1",
-          "courtId" to "TSTCRT",
-          "madeByTheCourt" to false,
-          "main" to mapOf(
-            "locationId" to 1,
-            "startTime" to referenceTime.plusMinutes(30).format(ISO_LOCAL_DATE_TIME),
-            "endTime" to referenceTime.plusMinutes(60).format(ISO_LOCAL_DATE_TIME)
+      webTestClient.post()
+        .uri("/court/video-link-bookings")
+        .headers(setHeaders())
+        .bodyValue(
+          mapOf(
+            "bookingId" to bookingId,
+            "court" to "Test Court 1",
+            "courtId" to "TSTCRT",
+            "madeByTheCourt" to false,
+            "main" to mapOf(
+              "locationId" to 1,
+              "startTime" to referenceTime.plusMinutes(30).format(ISO_LOCAL_DATE_TIME),
+              "endTime" to referenceTime.plusMinutes(60).format(ISO_LOCAL_DATE_TIME)
+            )
           )
         )
-      )
-      .exchange()
-      .expectStatus().isCreated
-      .expectBody().json("1")
+        .exchange()
+        .expectStatus().isCreated
+        .expectBody().jsonPath("$").isNumber
 
-    verify(videoLinkBookingRepository).save(theVideoLinkBooking)
-  }
+      val bookings = videoLinkBookingRepository.findAll()
+      assertThat(bookings).hasSize(1)
 
-  @Test
-  fun `Failed POST video-link-bookings, invalid main start time`() {
-    val bookingId = 1L
+      assertThat(bookings[0])
+        .usingRecursiveComparison()
+        .ignoringFields("id", "appointments.id", "appointments.videoLinkBooking")
+        .isEqualTo(
+          VideoLinkBooking(
+            offenderBookingId = bookingId,
+            courtName = "Test Court 1",
+            courtId = "TSTCRT",
+            madeByTheCourt = false,
+            createdByUsername = "ITAG_USER"
+          ).apply {
+            addMainAppointment(mainAppointmentId)
+          }
+        )
+    }
 
-    webTestClient.post()
-      .uri("/court/video-link-bookings")
-      .headers(setHeaders())
-      .bodyValue(
-        mapOf(
-          "bookingId" to bookingId,
-          "court" to "Test Court 1",
-          "madeByTheCourt" to false,
-          "main" to mapOf(
-            "locationId" to 1,
-            "startTime" to yesterday.plusMinutes(30).format(ISO_LOCAL_DATE_TIME),
-            "endTime" to yesterday.plusMinutes(60).format(ISO_LOCAL_DATE_TIME)
+    @Test
+    fun `Failed POST video-link-bookings, invalid main start time`() {
+      val bookingId = 1L
+
+      webTestClient.post()
+        .uri("/court/video-link-bookings")
+        .headers(setHeaders())
+        .bodyValue(
+          mapOf(
+            "bookingId" to bookingId,
+            "court" to "Test Court 1",
+            "madeByTheCourt" to false,
+            "main" to mapOf(
+              "locationId" to 1,
+              "startTime" to yesterday.plusMinutes(30).format(ISO_LOCAL_DATE_TIME),
+              "endTime" to yesterday.plusMinutes(60).format(ISO_LOCAL_DATE_TIME)
+            )
           )
         )
-      )
-      .exchange()
-      .expectStatus().isBadRequest
+        .exchange()
+        .expectStatus().isBadRequest
+    }
   }
 
-  @Test
-  fun `Returns 404 when trying to delete a non-existent video link booking`() {
-    val bookingId: Long = 1
+  @Nested
+  inner class DeleteBooking {
+    @BeforeEach
+    fun resetVideoLinkBookings() {
+      JdbcTestUtils.deleteFromTables(jdbcTemplate, "VIDEO_LINK_APPOINTMENT", "VIDEO_LINK_BOOKING")
+    }
 
-    webTestClient.delete()
-      .uri("/court/video-link-bookings/$bookingId")
-      .headers(setHeaders())
-      .exchange()
-      .expectStatus().isNotFound
-      .expectBody()
-      .jsonPath("$.developerMessage").isEqualTo("Video link booking with id $bookingId not found")
-  }
+    @Test
+    fun `Returns 404 when trying to delete a non-existent video link booking`() {
+      val bookingId: Long = 1
 
-  @Test
-  fun `Returns 204 when successfully deleting a booking`() {
-    val videoBookingId: Long = 1
-    val preAppointmentId: Long = 2
-    val mainAppointmentId: Long = 3
+      webTestClient.delete()
+        .uri("/court/video-link-bookings/$bookingId")
+        .headers(setHeaders())
+        .exchange()
+        .expectStatus().isNotFound
+        .expectBody()
+        .jsonPath("$.developerMessage").isEqualTo("Video link booking with id $bookingId not found")
+    }
 
-    val theVideoLinkBooking = VideoLinkBooking(
-      id = videoBookingId,
-      pre = VideoLinkAppointment(
-        id = 10,
-        bookingId = 4,
-        appointmentId = preAppointmentId,
-        court = "Test Court 1",
-        courtId = null,
-        hearingType = HearingType.PRE
-      ),
-      main = VideoLinkAppointment(
-        id = 11,
-        bookingId = 4,
-        appointmentId = mainAppointmentId,
-        court = "Test Court 2",
-        courtId = null,
-        hearingType = HearingType.MAIN
+    @Test
+    fun `Returns 204 when successfully deleting a booking`() {
+
+      val preAppointmentId: Long = 2
+      val mainAppointmentId: Long = 3
+
+      val persistentBooking = videoLinkBookingRepository.save(
+        VideoLinkBooking(
+          offenderBookingId = 4,
+          courtName = "Test Court 1",
+          courtId = null
+        ).apply {
+          addPreAppointment(appointmentId = preAppointmentId)
+          addMainAppointment(appointmentId = mainAppointmentId)
+        }
       )
-    )
 
-    whenever(videoLinkBookingRepository.findById(videoBookingId)).thenReturn(Optional.of(theVideoLinkBooking))
+      assertThat(JdbcTestUtils.countRowsInTable(jdbcTemplate, "video_link_booking")).isEqualTo(1)
+      assertThat(JdbcTestUtils.countRowsInTable(jdbcTemplate, "video_link_appointment")).isEqualTo(2)
 
-    prisonApiMockServer.stubDeleteAppointment(preAppointmentId, 200)
-    prisonApiMockServer.stubDeleteAppointment(mainAppointmentId, 404)
+      prisonApiMockServer.stubDeleteAppointment(preAppointmentId, 200)
+      prisonApiMockServer.stubDeleteAppointment(mainAppointmentId, 404)
 
-    webTestClient.delete()
-      .uri("/court/video-link-bookings/$videoBookingId")
-      .headers(setHeaders())
-      .exchange()
-      .expectStatus().isNoContent
+      webTestClient.delete()
+        .uri("/court/video-link-bookings/${persistentBooking.id}")
+        .headers(setHeaders())
+        .exchange()
+        .expectStatus().isNoContent
 
-    prisonApiMockServer.verify(
-      WireMock.deleteRequestedFor(WireMock.urlEqualTo("/api/appointments/$preAppointmentId"))
-    )
-    prisonApiMockServer.verify(
-      WireMock.deleteRequestedFor(WireMock.urlEqualTo("/api/appointments/$mainAppointmentId"))
-    )
+      prisonApiMockServer.verify(
+        WireMock.deleteRequestedFor(WireMock.urlEqualTo("/api/appointments/$preAppointmentId"))
+      )
+      prisonApiMockServer.verify(
+        WireMock.deleteRequestedFor(WireMock.urlEqualTo("/api/appointments/$mainAppointmentId"))
+      )
 
-    verify(videoLinkBookingRepository).deleteById(videoBookingId)
+      assertThat(JdbcTestUtils.countRowsInTable(jdbcTemplate, "video_link_booking")).isEqualTo(0)
+      assertThat(JdbcTestUtils.countRowsInTable(jdbcTemplate, "video_link_appointment")).isEqualTo(0)
+    }
   }
 
   @Nested
   inner class UpdateBooking {
+
+    @BeforeEach
+    fun resetVideoLinkBookings() {
+      JdbcTestUtils.deleteFromTables(jdbcTemplate, "VIDEO_LINK_APPOINTMENT", "VIDEO_LINK_BOOKING")
+    }
+
     @Test
     fun `Updates a booking`() {
       val offenderBookingId = 1L
@@ -402,30 +425,27 @@ class CourtIntegrationTest : IntegrationTest() {
       prisonApiMockServer.stubDeleteAppointment(oldAppointmentId, status = 204)
       prisonApiMockServer.stubAddAppointmentForBooking(offenderBookingId, eventId = newAppointmentId)
 
-      val theVideoLinkBooking = VideoLinkBooking(
-        main = VideoLinkAppointment(
-          bookingId = offenderBookingId,
-          appointmentId = newAppointmentId,
-          court = "Test Court 1",
+      val persistentBooking = videoLinkBookingRepository.save(
+        VideoLinkBooking(
+          offenderBookingId = offenderBookingId,
+          courtName = "Test Court 1",
           courtId = "TSTCRT",
-          madeByTheCourt = false,
-          hearingType = HearingType.MAIN
-        )
+          madeByTheCourt = false
+        ).apply {
+          addMainAppointment(appointmentId = oldAppointmentId)
+        }
       )
 
-      whenever(videoLinkBookingRepository.findById(1L))
-        .thenReturn(Optional.of(theVideoLinkBooking.copy(id = 1)))
-
       webTestClient.put()
-        .uri("/court/video-link-bookings/1")
+        .uri("/court/video-link-bookings/${persistentBooking.id}")
         .bodyValue(
           """
               {
                 "comment": "New comment",
                 "madeByTheCourt": false,
                 "main": {
-                  "locationId" : 2,
-                  "startTime" : "${referenceTime.format(ISO_LOCAL_DATE_TIME)}",
+                  "locationId": 2,
+                  "startTime": "${referenceTime.format(ISO_LOCAL_DATE_TIME)}",
                   "endTime": "${referenceTime.plusMinutes(30).format(ISO_LOCAL_DATE_TIME)}"
                 }
               }
@@ -434,8 +454,6 @@ class CourtIntegrationTest : IntegrationTest() {
         .headers(setHeaders())
         .exchange()
         .expectStatus().isNoContent
-
-      verify(videoLinkBookingRepository).findById(1L)
     }
 
     @Test
@@ -475,26 +493,27 @@ class CourtIntegrationTest : IntegrationTest() {
   inner class UpdateBookingComment {
 
     val theVideoLinkBooking = VideoLinkBooking(
-      main = VideoLinkAppointment(
-        bookingId = 1L,
-        appointmentId = 10L,
-        court = "Test Court 1",
-        courtId = null,
-        madeByTheCourt = true,
-        hearingType = HearingType.MAIN
-      )
-    )
+      offenderBookingId = 1L,
+      courtName = "Test Court 1",
+      courtId = null,
+      madeByTheCourt = true
+    ).apply {
+      addMainAppointment(10L)
+    }
+
+    @BeforeEach
+    fun resetVideoLinkBookings() {
+      JdbcTestUtils.deleteFromTables(jdbcTemplate, "VIDEO_LINK_APPOINTMENT", "VIDEO_LINK_BOOKING")
+    }
 
     @Test
     fun `Updates a comment`() {
-
-      whenever(videoLinkBookingRepository.findById(1L))
-        .thenReturn(Optional.of(theVideoLinkBooking.copy(id = 1)))
+      val persistentBookingId = videoLinkBookingRepository.save(theVideoLinkBooking).id!!
 
       prisonApiMockServer.stubUpdateAppointmentComment(1L)
 
       webTestClient.put()
-        .uri("/court/video-link-bookings/1/comment")
+        .uri("/court/video-link-bookings/$persistentBookingId/comment")
         .bodyValue("New Comment")
         .headers(setHeaders(contentType = MediaType.TEXT_PLAIN))
         .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/model/VideoLinkAppointmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/model/VideoLinkAppointmentTest.kt
@@ -1,0 +1,46 @@
+package uk.gov.justice.digital.hmpps.whereabouts.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class VideoLinkAppointmentTest {
+  @Test
+  fun `toString check`() {
+    assertThat(
+      VideoLinkAppointment(
+        appointmentId = 1L,
+        hearingType = HearingType.MAIN,
+        videoLinkBooking = VideoLinkBooking(offenderBookingId = 2L)
+      ).toString()
+    ).isEqualTo("VideoLinkAppointment(id = null, appointmentId = 1, hearingType = MAIN)")
+  }
+
+  @Test
+  fun `equality by appointmentId same id`() {
+    val dontCareBooking = VideoLinkBooking(offenderBookingId = 1)
+    val vla1 = VideoLinkAppointment(id = 1, appointmentId = 2, hearingType = HearingType.MAIN, videoLinkBooking = dontCareBooking)
+    val vla2 = VideoLinkAppointment(id = 1, appointmentId = 2, hearingType = HearingType.MAIN, videoLinkBooking = dontCareBooking)
+    assertThat(vla1.equals(vla2)).isTrue
+  }
+
+  @Test
+  fun `equality other null`() {
+    val dontCareBooking = VideoLinkBooking(offenderBookingId = 1)
+    val vla1 = VideoLinkAppointment(id = 1, appointmentId = 2, hearingType = HearingType.MAIN, videoLinkBooking = dontCareBooking)
+    assertThat(vla1.equals(null)).isFalse
+  }
+
+  @Test
+  fun `equality other not a VideoLinkAppointment`() {
+    val dontCareBooking = VideoLinkBooking(offenderBookingId = 1)
+    val vla1 = VideoLinkAppointment(id = 1, appointmentId = 2, hearingType = HearingType.MAIN, videoLinkBooking = dontCareBooking)
+    assertThat(vla1.equals(object {})).isFalse
+  }
+
+  // @Test
+  // fun `equality other is sub-class with matching appointmentId`() {
+  //   val dontCareBooking = VideoLinkBooking(offenderBookingId = 1)
+  //   val vla1 = VideoLinkAppointment(id=1, appointmentId = 2, hearingType = HearingType.MAIN, videoLinkBooking = dontCareBooking)
+  //   assertThat(vla1.equals(object: VideoLinkAppointment(appointmentId = 2, hearingType = HearingType.PRE, videoLinkBooking = dontCareBooking){})).isTrue
+  // }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/model/VideoLinkAppointmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/model/VideoLinkAppointmentTest.kt
@@ -36,11 +36,4 @@ class VideoLinkAppointmentTest {
     val vla1 = VideoLinkAppointment(id = 1, appointmentId = 2, hearingType = HearingType.MAIN, videoLinkBooking = dontCareBooking)
     assertThat(vla1.equals(object {})).isFalse
   }
-
-  // @Test
-  // fun `equality other is sub-class with matching appointmentId`() {
-  //   val dontCareBooking = VideoLinkBooking(offenderBookingId = 1)
-  //   val vla1 = VideoLinkAppointment(id=1, appointmentId = 2, hearingType = HearingType.MAIN, videoLinkBooking = dontCareBooking)
-  //   assertThat(vla1.equals(object: VideoLinkAppointment(appointmentId = 2, hearingType = HearingType.PRE, videoLinkBooking = dontCareBooking){})).isTrue
-  // }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/model/VideoLinkBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/model/VideoLinkBookingTest.kt
@@ -17,36 +17,6 @@ class VideoLinkBookingTest {
   }
 
   @Test
-  fun `matches no court or courtId`() {
-    assertThat(videoLinkBooking.matchesCourt(null, null)).isTrue
-  }
-
-  @Test
-  fun `matching court`() {
-    assertThat(videoLinkBooking.matchesCourt(COURT_NAME, null)).isTrue
-  }
-
-  @Test
-  fun `no matching court`() {
-    assertThat(videoLinkBooking.matchesCourt("Some other court", null)).isFalse
-  }
-
-  @Test
-  fun `matching courtId`() {
-    assertThat(videoLinkBooking.matchesCourt(null, COURT_ID)).isTrue
-  }
-
-  @Test
-  fun `no matching courtId`() {
-    assertThat(videoLinkBooking.matchesCourt(null, "XXX")).isFalse
-  }
-
-  @Test
-  fun `courtId takes precedence over court name`() {
-    assertThat(videoLinkBooking.matchesCourt("Some other court", COURT_ID)).isTrue
-  }
-
-  @Test
   fun `preApppointment`() {
     assertThat(videoLinkBooking.appointments[PRE])
       .isNotNull()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/model/VideoLinkBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/model/VideoLinkBookingTest.kt
@@ -2,48 +2,79 @@ package uk.gov.justice.digital.hmpps.whereabouts.model
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.whereabouts.model.HearingType.MAIN
+import uk.gov.justice.digital.hmpps.whereabouts.model.HearingType.POST
+import uk.gov.justice.digital.hmpps.whereabouts.model.HearingType.PRE
 
 class VideoLinkBookingTest {
   val COURT_NAME = "The Court"
   val COURT_ID = "TC"
 
-  var videoLinkBooking = VideoLinkBooking(
-    main = VideoLinkAppointment(
-      court = COURT_NAME,
-      courtId = COURT_ID,
-      bookingId = 1L,
-      hearingType = HearingType.MAIN,
-      appointmentId = -1L
-    )
-  )
+  var videoLinkBooking = VideoLinkBooking(courtName = COURT_NAME, courtId = COURT_ID, offenderBookingId = 1L).apply {
+    addPreAppointment(appointmentId = 1L)
+    addMainAppointment(appointmentId = 2L)
+    addPostAppointment(appointmentId = 3L)
+  }
 
   @Test
   fun `matches no court or courtId`() {
-    assertThat(videoLinkBooking.matchesCourt(null, null)).isTrue()
+    assertThat(videoLinkBooking.matchesCourt(null, null)).isTrue
   }
 
   @Test
   fun `matching court`() {
-    assertThat(videoLinkBooking.matchesCourt(COURT_NAME, null)).isTrue()
+    assertThat(videoLinkBooking.matchesCourt(COURT_NAME, null)).isTrue
   }
 
   @Test
   fun `no matching court`() {
-    assertThat(videoLinkBooking.matchesCourt("Some other court", null)).isFalse()
+    assertThat(videoLinkBooking.matchesCourt("Some other court", null)).isFalse
   }
 
   @Test
   fun `matching courtId`() {
-    assertThat(videoLinkBooking.matchesCourt(null, COURT_ID)).isTrue()
+    assertThat(videoLinkBooking.matchesCourt(null, COURT_ID)).isTrue
   }
 
   @Test
   fun `no matching courtId`() {
-    assertThat(videoLinkBooking.matchesCourt(null, "XXX")).isFalse()
+    assertThat(videoLinkBooking.matchesCourt(null, "XXX")).isFalse
   }
 
   @Test
   fun `courtId takes precedence over court name`() {
-    assertThat(videoLinkBooking.matchesCourt("Some other court", COURT_ID)).isTrue()
+    assertThat(videoLinkBooking.matchesCourt("Some other court", COURT_ID)).isTrue
+  }
+
+  @Test
+  fun `preApppointment`() {
+    assertThat(videoLinkBooking.appointments[PRE])
+      .isNotNull()
+      .extracting("appointmentId", "hearingType")
+      .containsExactly(1L, PRE)
+  }
+
+  @Test
+  fun `mainApppointment`() {
+    assertThat(videoLinkBooking.appointments[MAIN])
+      .isNotNull()
+      .extracting("appointmentId", "hearingType")
+      .containsExactly(2L, MAIN)
+  }
+
+  @Test
+  fun `postApppointment`() {
+    assertThat(videoLinkBooking.appointments[POST])
+      .isNotNull()
+      .extracting("appointmentId", "hearingType")
+      .containsExactly(3L, POST)
+  }
+
+  @Test
+  fun `no appointments`() {
+    val vlb = VideoLinkBooking(offenderBookingId = 1L)
+    assertThat(vlb.appointments[PRE]).isNull()
+    assertThat(vlb.appointments[MAIN]).isNull()
+    assertThat(vlb.appointments[POST]).isNull()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/repository/VideoLinkBookingRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/repository/VideoLinkBookingRepositoryTest.kt
@@ -191,6 +191,54 @@ class VideoLinkBookingRepositoryTest(
   }
 
   @Test
+  fun `findByAppointmentIdsAndHearingType filter by courtName`() {
+    repository.save(VideoLinkBooking(offenderBookingId = 1L, courtName = "C1").apply { addMainAppointment(100L) })
+    repository.save(VideoLinkBooking(offenderBookingId = 2L, courtName = "C2").apply { addMainAppointment(101L) })
+    repository.save(VideoLinkBooking(offenderBookingId = 3L, courtName = "C1").apply { addMainAppointment(102L) })
+    repository.save(VideoLinkBooking(offenderBookingId = 4L, courtName = "C2").apply { addMainAppointment(103L) })
+
+    TestTransaction.flagForCommit()
+    TestTransaction.end()
+    TestTransaction.start()
+
+    assertThat(repository.findByAppointmentIdsAndHearingType(listOf(100L, 101L), MAIN))
+      .extracting("offenderBookingId")
+      .containsExactlyInAnyOrder(1L, 2L)
+
+    assertThat(repository.findByAppointmentIdsAndHearingType(listOf(100L, 101L), MAIN, courtName = "C1"))
+      .extracting("offenderBookingId")
+      .containsExactlyInAnyOrder(1L)
+
+    assertThat(repository.findByAppointmentIdsAndHearingType(listOf(100L, 101L), MAIN, courtName = "C2"))
+      .extracting("offenderBookingId")
+      .containsExactlyInAnyOrder(2L)
+  }
+
+  @Test
+  fun `findByAppointmentIdsAndHearingType filter by courtId`() {
+    repository.save(VideoLinkBooking(offenderBookingId = 1L, courtId = "C1").apply { addMainAppointment(100L) })
+    repository.save(VideoLinkBooking(offenderBookingId = 2L, courtId = "C2").apply { addMainAppointment(101L) })
+    repository.save(VideoLinkBooking(offenderBookingId = 3L, courtId = "C1").apply { addMainAppointment(102L) })
+    repository.save(VideoLinkBooking(offenderBookingId = 4L, courtId = "C2").apply { addMainAppointment(103L) })
+
+    TestTransaction.flagForCommit()
+    TestTransaction.end()
+    TestTransaction.start()
+
+    assertThat(repository.findByAppointmentIdsAndHearingType(listOf(100L, 101L), MAIN))
+      .extracting("offenderBookingId")
+      .containsExactlyInAnyOrder(1L, 2L)
+
+    assertThat(repository.findByAppointmentIdsAndHearingType(listOf(100L, 101L), MAIN, courtId = "C1"))
+      .extracting("offenderBookingId")
+      .containsExactlyInAnyOrder(1L)
+
+    assertThat(repository.findByAppointmentIdsAndHearingType(listOf(100L, 101L), MAIN, courtId = "C2"))
+      .extracting("offenderBookingId")
+      .containsExactlyInAnyOrder(2L)
+  }
+
+  @Test
   fun `Removing appointments from a booking should delete the appointments`() {
 
     val id = repository.save(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/repository/VideoLinkBookingRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/repository/VideoLinkBookingRepositoryTest.kt
@@ -64,7 +64,7 @@ class VideoLinkBookingRepositoryTest(
     TestTransaction.flagForCommit()
     TestTransaction.end()
 
-    val persistentBooking = repository.getOne(id)
+    val persistentBooking = repository.getById(id)
 
     assertThat(persistentBooking)
       .usingRecursiveComparison()
@@ -93,7 +93,7 @@ class VideoLinkBookingRepositoryTest(
     TestTransaction.flagForCommit()
     TestTransaction.end()
 
-    val persistentBooking = repository.getOne(id)
+    val persistentBooking = repository.getById(id)
 
     assertThat(persistentBooking)
       .usingRecursiveComparison()
@@ -177,8 +177,9 @@ class VideoLinkBookingRepositoryTest(
     val bookings = repository.findByAppointmentIdsAndHearingType((-999L..1000L step 2).map { it }, MAIN)
     assertThat(bookings).hasSize(5)
 
-    val appointmentIds = bookings.map { it.appointments[MAIN]?.appointmentId }
-    assertThat(appointmentIds).containsExactlyInAnyOrder(1L, 3L, 5L, 7L, 9L)
+    assertThat(bookings.map { it.appointments[PRE]?.appointmentId }).containsExactlyInAnyOrder(2L, 8L, 14L, 20L, 26L)
+    assertThat(bookings.map { it.appointments[MAIN]?.appointmentId }).containsExactlyInAnyOrder(3L, 9L, 15L, 21L, 27L)
+    assertThat(bookings.map { it.appointments[POST]?.appointmentId }).containsExactlyInAnyOrder(4L, 10L, 16L, 22L, 28L)
   }
 
   @Test
@@ -196,7 +197,7 @@ class VideoLinkBookingRepositoryTest(
     TestTransaction.end()
     TestTransaction.start()
 
-    val booking = repository.getOne(id)
+    val booking = repository.getById(id)
 
     booking.appointments.remove(PRE)
     booking.appointments.remove(POST)
@@ -226,7 +227,7 @@ class VideoLinkBookingRepositoryTest(
     TestTransaction.end()
     TestTransaction.start()
 
-    val booking = repository.getOne(id)
+    val booking = repository.getById(id)
 
     /**
      * Have to flush() to force Hibernate to delete any old appointments before adding replacements.
@@ -256,7 +257,7 @@ class VideoLinkBookingRepositoryTest(
 
     assertThat(JdbcTestUtils.countRowsInTable(jdbcTemplate, "VIDEO_LINK_APPOINTMENT")).isEqualTo(3)
 
-    val updatedBooking = repository.getOne(id)
+    val updatedBooking = repository.getById(id)
     assertThat(updatedBooking.appointments.values.map { it.appointmentId }).contains(100, 101, 102)
   }
 
@@ -268,7 +269,9 @@ class VideoLinkBookingRepositoryTest(
         courtId = "TSTCRT",
         madeByTheCourt = true
       ).apply {
-        addMainAppointment(appointmentId = it)
+        addPreAppointment(appointmentId = it * 3 - 1)
+        addMainAppointment(appointmentId = it * 3)
+        addPostAppointment(appointmentId = it * 3 + 1)
       }
     }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/repository/VideoLinkBookingRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/repository/VideoLinkBookingRepositoryTest.kt
@@ -166,15 +166,23 @@ class VideoLinkBookingRepositoryTest(
   }
 
   @Test
-  fun `findByMainAppointmentIds no Ids`() {
+  fun `findByAppointmentIdsAndHearingType no Ids`() {
     assertThat(repository.findByAppointmentIdsAndHearingType(listOf(), MAIN)).isEmpty()
   }
 
   @Test
-  fun `findByMainAppointmentIds sparse`() {
+  fun `findByAppointmentIdsAndHearingType sparse`() {
     repository.saveAll(videoLinkBookings())
 
-    val bookings = repository.findByAppointmentIdsAndHearingType((-999L..1000L step 2).map { it }, MAIN)
+    // commit and start new transaction so that Hibernate doesn't pull persisted objects from the session cache
+    TestTransaction.flagForCommit()
+    TestTransaction.end()
+
+    TestTransaction.start()
+
+    // -9 ... -1, 1, 3, 5, ... 39
+    val appointmentIds = (-9L..40L step 2).map { it }
+    val bookings = repository.findByAppointmentIdsAndHearingType(appointmentIds, MAIN)
     assertThat(bookings).hasSize(5)
 
     assertThat(bookings.map { it.appointments[PRE]?.appointmentId }).containsExactlyInAnyOrder(2L, 8L, 14L, 20L, 26L)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/AppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/AppointmentServiceTest.kt
@@ -301,7 +301,7 @@ class AppointmentServiceTest {
     fun `check to see if the appointment is a video link booking`() {
       appointmentService.getAppointment(1)
 
-      verify(videoLinkBookingRepository).findByMainAppointmentIds(listOf(1))
+      verify(videoLinkBookingRepository).findByAppointmentIdsAndHearingType(listOf(1), HearingType.MAIN)
     }
 
     @Test
@@ -356,7 +356,7 @@ class AppointmentServiceTest {
 
     @Test
     fun `transform into video link booking`() {
-      whenever(videoLinkBookingRepository.findByMainAppointmentIds(any())).thenReturn(
+      whenever(videoLinkBookingRepository.findByAppointmentIdsAndHearingType(any(), eq(HearingType.MAIN))).thenReturn(
         listOf(DataHelpers.makeVideoLinkBooking(1L))
       )
 
@@ -442,7 +442,7 @@ class AppointmentServiceTest {
           )
         )
 
-      whenever(videoLinkBookingRepository.findByMainAppointmentIds(any())).thenReturn(
+      whenever(videoLinkBookingRepository.findByAppointmentIdsAndHearingType(any(), eq(HearingType.MAIN))).thenReturn(
         listOf(DataHelpers.makeVideoLinkBooking(4L))
       )
 
@@ -643,7 +643,7 @@ class AppointmentServiceTest {
 
     @Test
     fun `should delete video link booking`() {
-      whenever(videoLinkBookingRepository.findByMainAppointmentIds(any())).thenReturn(
+      whenever(videoLinkBookingRepository.findByAppointmentIdsAndHearingType(any(), eq(HearingType.MAIN))).thenReturn(
         listOf(DataHelpers.makeVideoLinkBooking(2L))
       )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/AppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/AppointmentServiceTest.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.isA
+import com.nhaarman.mockitokotlin2.isNull
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.reset
@@ -356,7 +357,14 @@ class AppointmentServiceTest {
 
     @Test
     fun `transform into video link booking`() {
-      whenever(videoLinkBookingRepository.findByAppointmentIdsAndHearingType(any(), eq(HearingType.MAIN))).thenReturn(
+      whenever(
+        videoLinkBookingRepository.findByAppointmentIdsAndHearingType(
+          any(),
+          eq(HearingType.MAIN),
+          isNull(),
+          isNull()
+        )
+      ).thenReturn(
         listOf(DataHelpers.makeVideoLinkBooking(1L))
       )
 
@@ -442,7 +450,14 @@ class AppointmentServiceTest {
           )
         )
 
-      whenever(videoLinkBookingRepository.findByAppointmentIdsAndHearingType(any(), eq(HearingType.MAIN))).thenReturn(
+      whenever(
+        videoLinkBookingRepository.findByAppointmentIdsAndHearingType(
+          any(),
+          eq(HearingType.MAIN),
+          isNull(),
+          isNull()
+        )
+      ).thenReturn(
         listOf(DataHelpers.makeVideoLinkBooking(4L))
       )
 
@@ -643,7 +658,14 @@ class AppointmentServiceTest {
 
     @Test
     fun `should delete video link booking`() {
-      whenever(videoLinkBookingRepository.findByAppointmentIdsAndHearingType(any(), eq(HearingType.MAIN))).thenReturn(
+      whenever(
+        videoLinkBookingRepository.findByAppointmentIdsAndHearingType(
+          any(),
+          eq(HearingType.MAIN),
+          isNull(),
+          isNull()
+        )
+      ).thenReturn(
         listOf(DataHelpers.makeVideoLinkBooking(2L))
       )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/court/ApplicationInsightsEventListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/court/ApplicationInsightsEventListenerTest.kt
@@ -32,7 +32,7 @@ class ApplicationInsightsEventListenerTest {
       "VideoLinkBookingCreated",
       mapOf(
         "id" to "11",
-        "bookingId" to "1",
+        "bookingId" to "-1",
         "court" to "York Crown Court",
         "agencyId" to "WWI",
         "user" to "A_USER",
@@ -63,7 +63,7 @@ class ApplicationInsightsEventListenerTest {
       mapOf(
         "id" to "11",
         "user" to "A_USER",
-        "bookingId" to "1",
+        "bookingId" to "-1",
         "court" to "York Crown Court",
         "preAppointmentId" to "12",
         "preId" to "120",
@@ -91,7 +91,7 @@ class ApplicationInsightsEventListenerTest {
       mapOf(
         "id" to "11",
         "user" to "A_USER",
-        "bookingId" to "1",
+        "bookingId" to "-1",
         "court" to "York Crown Court",
         "preAppointmentId" to "12",
         "preId" to "120",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/court/CourtServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/court/CourtServiceTest.kt
@@ -55,12 +55,12 @@ class CourtServiceTest {
   inner class FindName {
     @Test
     fun `found`() {
-      assertThat(CourtService(repository).findName(DERBY_JC_ID)).isEqualTo(DERBY_JC_NAME)
+      assertThat(CourtService(repository).getCourtNameForCourtId(DERBY_JC_ID)).isEqualTo(DERBY_JC_NAME)
     }
 
     @Test
     fun `Not Found`() {
-      assertThat(CourtService(repository).findName("XXXX")).isNull()
+      assertThat(CourtService(repository).getCourtNameForCourtId("XXXX")).isNull()
     }
   }
 
@@ -68,12 +68,12 @@ class CourtServiceTest {
   inner class FindId {
     @Test
     fun `perfect match`() {
-      assertThat(CourtService(repository).findId(DERBY_JC_NAME)).isEqualTo(DERBY_JC_ID)
+      assertThat(CourtService(repository).getCourtIdForCourtName(DERBY_JC_NAME)).isEqualTo(DERBY_JC_ID)
     }
 
     @Test
     fun `case insensitive match with whitespace`() {
-      assertThat(CourtService(repository).findId(" ${DERBY_JC_NAME.uppercase()}  ")).isEqualTo(DERBY_JC_ID)
+      assertThat(CourtService(repository).getCourtIdForCourtName(" ${DERBY_JC_NAME.uppercase()}  ")).isEqualTo(DERBY_JC_ID)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/court/EventListenerTestData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/court/EventListenerTestData.kt
@@ -3,8 +3,6 @@ package uk.gov.justice.digital.hmpps.whereabouts.services.court
 import uk.gov.justice.digital.hmpps.whereabouts.dto.VideoLinkAppointmentSpecification
 import uk.gov.justice.digital.hmpps.whereabouts.dto.VideoLinkBookingSpecification
 import uk.gov.justice.digital.hmpps.whereabouts.dto.VideoLinkBookingUpdateSpecification
-import uk.gov.justice.digital.hmpps.whereabouts.model.HearingType
-import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkAppointment
 import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkBooking
 import java.time.LocalDateTime
 
@@ -15,10 +13,14 @@ class EventListenerTestData private constructor() {
 
     val booking = VideoLinkBooking(
       id = 11,
-      pre = VideoLinkAppointment(120L, -1L, 12L, "York Crown Court", "TSTCRT", hearingType = HearingType.PRE, createdByUsername = "A_USER", madeByTheCourt = true),
-      main = VideoLinkAppointment(130L, 1L, 13L, "York Crown Court", "TSTCRT", hearingType = HearingType.MAIN, createdByUsername = "A_USER", madeByTheCourt = true),
-      post = VideoLinkAppointment(140L, -1L, 14L, "York Crown Court", "TSTCRT", hearingType = HearingType.POST, createdByUsername = "A_USER", madeByTheCourt = true),
-    )
+      offenderBookingId = -1L,
+      courtName = "York Crown Court",
+      courtId = "TSTCRT"
+    ).apply {
+      addPreAppointment(appointmentId = 12L, id = 120L)
+      addMainAppointment(appointmentId = 13L, id = 130L)
+      addPostAppointment(appointmentId = 14L, id = 140L)
+    }
 
     val createSpecification = VideoLinkBookingSpecification(
       bookingId = 1L,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/court/EventStoreListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/court/EventStoreListenerTest.kt
@@ -5,6 +5,9 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.whereabouts.model.HearingType.MAIN
+import uk.gov.justice.digital.hmpps.whereabouts.model.HearingType.POST
+import uk.gov.justice.digital.hmpps.whereabouts.model.HearingType.PRE
 import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkBookingEvent
 import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkBookingEventType
 import uk.gov.justice.digital.hmpps.whereabouts.repository.VideoLinkBookingEventRepository
@@ -44,16 +47,16 @@ class EventStoreListenerTest {
         comment = createSpecification.comment,
         offenderBookingId = createSpecification.bookingId,
         madeByTheCourt = createSpecification.madeByTheCourt,
-        mainNomisAppointmentId = booking.main.appointmentId,
+        mainNomisAppointmentId = booking.appointments[MAIN]!!.appointmentId,
         mainLocationId = createSpecification.main.locationId,
         mainStartTime = createSpecification.main.startTime,
         mainEndTime = createSpecification.main.endTime,
-        preNomisAppointmentId = booking.pre!!.appointmentId,
+        preNomisAppointmentId = booking.appointments[PRE]!!.appointmentId,
         preLocationId = createSpecification.pre!!.locationId,
         preStartTime = createSpecification.pre!!.startTime,
         preEndTime = createSpecification.pre!!.endTime,
         postLocationId = createSpecification.post!!.locationId,
-        postNomisAppointmentId = booking.post!!.appointmentId,
+        postNomisAppointmentId = booking.appointments[POST]!!.appointmentId,
         postStartTime = createSpecification.post!!.startTime,
         postEndTime = createSpecification.post!!.endTime
       )
@@ -71,16 +74,16 @@ class EventStoreListenerTest {
         userId = "A_USER",
         videoLinkBookingId = booking.id!!,
         comment = updateSpecification.comment,
-        mainNomisAppointmentId = booking.main.appointmentId,
+        mainNomisAppointmentId = booking.appointments[MAIN]!!.appointmentId,
         mainLocationId = updateSpecification.main.locationId,
         mainStartTime = updateSpecification.main.startTime,
         mainEndTime = updateSpecification.main.endTime,
-        preNomisAppointmentId = booking.pre!!.appointmentId,
+        preNomisAppointmentId = booking.appointments[PRE]!!.appointmentId,
         preLocationId = updateSpecification.pre!!.locationId,
         preStartTime = updateSpecification.pre!!.startTime,
         preEndTime = updateSpecification.pre!!.endTime,
         postLocationId = updateSpecification.post!!.locationId,
-        postNomisAppointmentId = booking.post!!.appointmentId,
+        postNomisAppointmentId = booking.appointments[POST]!!.appointmentId,
         postStartTime = updateSpecification.post!!.startTime,
         postEndTime = updateSpecification.post!!.endTime
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/court/VideoLinkBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/court/VideoLinkBookingServiceTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.whereabouts.services.court
 
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.isA
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
@@ -72,20 +73,20 @@ class VideoLinkBookingServiceTest {
       setOf(
         VideoLinkAppointment(
           id = 1,
-          bookingId = 2,
           appointmentId = 3,
           hearingType = HearingType.MAIN,
-          court = COURT_NAME,
-          courtId = null
+          videoLinkBooking = VideoLinkBooking(offenderBookingId = 2L, courtName = COURT_NAME, madeByTheCourt = true)
         ),
         VideoLinkAppointment(
           id = 2,
-          bookingId = 3,
           appointmentId = 4,
           hearingType = HearingType.PRE,
-          court = null,
-          courtId = COURT_ID,
-          madeByTheCourt = false
+          videoLinkBooking = VideoLinkBooking(
+            offenderBookingId = 3L,
+            courtName = COURT_NAME,
+            courtId = COURT_ID,
+            madeByTheCourt = false
+          )
         )
       )
     )
@@ -113,31 +114,8 @@ class VideoLinkBookingServiceTest {
     private val referenceNow = LocalDateTime.now(clock)
 
     private val mainAppointmentId = 12L
-    private val mainVideoLinkAppointment = VideoLinkAppointment(
-      appointmentId = mainAppointmentId,
-      bookingId = 1,
-      court = COURT_NAME,
-      courtId = COURT_ID,
-      hearingType = HearingType.MAIN
-    )
-
     private val preAppointmentId = 13L
-    private val preVideoLinkAppointment = VideoLinkAppointment(
-      appointmentId = preAppointmentId,
-      bookingId = 1,
-      court = COURT_NAME,
-      courtId = COURT_ID,
-      hearingType = HearingType.PRE
-    )
-
     private val postAppointmentId = 14L
-    private val postVideoLinkAppointment = VideoLinkAppointment(
-      appointmentId = postAppointmentId,
-      bookingId = 1,
-      court = COURT_NAME,
-      courtId = COURT_ID,
-      hearingType = HearingType.POST
-    )
 
     private val expectedVideoLinkBookingId = 11L
 
@@ -148,6 +126,13 @@ class VideoLinkBookingServiceTest {
 
     @Test
     fun `happy flow - Main appointment only - madeByTheCourt`() {
+
+      fun makeBooking(id: Long?) = VideoLinkBooking(
+        id = id,
+        offenderBookingId = 1L,
+        courtName = COURT_NAME,
+        courtId = COURT_ID
+      ).apply { addMainAppointment(mainAppointmentId) }
 
       val specification = VideoLinkBookingSpecification(
         bookingId = 1L,
@@ -162,15 +147,14 @@ class VideoLinkBookingServiceTest {
         )
       )
 
-      val booking = VideoLinkBooking(
-        id = expectedVideoLinkBookingId,
-        main = mainVideoLinkAppointment
+      whenever(prisonApiService.postAppointment(anyLong(), any())).thenReturn(
+        Event(
+          mainAppointmentId,
+          AGENCY_WANDSWORTH
+        )
       )
 
-      whenever(prisonApiService.postAppointment(anyLong(), any())).thenReturn(
-        Event(mainAppointmentId, AGENCY_WANDSWORTH)
-      )
-      whenever(videoLinkBookingRepository.save(any())).thenReturn(booking)
+      whenever(videoLinkBookingRepository.save(any())).thenReturn(makeBooking(expectedVideoLinkBookingId))
 
       val vlbBookingId = service.createVideoLinkBooking(specification)
 
@@ -187,8 +171,14 @@ class VideoLinkBookingServiceTest {
         )
       )
 
-      verify(videoLinkBookingRepository).save(booking.copy(id = null))
-      verify(videoLinkBookingEventListener).bookingCreated(booking, specification, AGENCY_WANDSWORTH)
+      // verify uses the equals method. The VideoLinkBooking equals method will return false for for two distinct objects that are deeply equal but not persistent.
+      // Hibernate equality is seriously annoying!
+      verify(videoLinkBookingRepository).save(makeBooking(null))
+      verify(videoLinkBookingEventListener).bookingCreated(
+        makeBooking(expectedVideoLinkBookingId),
+        specification,
+        AGENCY_WANDSWORTH
+      )
     }
 
     @Test
@@ -378,12 +368,18 @@ class VideoLinkBookingServiceTest {
 
       val offenderBookingId = 1L
 
-      val booking = VideoLinkBooking(
-        id = expectedVideoLinkBookingId,
-        pre = preVideoLinkAppointment.copy(madeByTheCourt = false, id = 20L),
-        main = mainVideoLinkAppointment.copy(madeByTheCourt = false, id = 21L),
-        post = postVideoLinkAppointment.copy(madeByTheCourt = false, id = 22L)
-      )
+      fun makeBooking(id: Long?) =
+        VideoLinkBooking(
+          id = id,
+          offenderBookingId = 1L,
+          courtName = COURT_NAME,
+          courtId = COURT_ID,
+          madeByTheCourt = false
+        ).apply {
+          addPreAppointment(appointmentId = preAppointmentId, id = 20L)
+          addMainAppointment(appointmentId = mainAppointmentId, id = 21L)
+          addPostAppointment(appointmentId = postAppointmentId, id = 22L)
+        }
 
       val mainCreateAppointment = CreateBookingAppointment(
         appointmentType = VLB_APPOINTMENT_TYPE,
@@ -428,7 +424,7 @@ class VideoLinkBookingServiceTest {
         )
       )
 
-      whenever(videoLinkBookingRepository.save(any())).thenReturn(booking)
+      whenever(videoLinkBookingRepository.save(any())).thenReturn(makeBooking(expectedVideoLinkBookingId))
 
       val vlbBookingId = service.createVideoLinkBooking(
         VideoLinkBookingSpecification(
@@ -461,14 +457,7 @@ class VideoLinkBookingServiceTest {
       verify(prisonApiService).postAppointment(offenderBookingId, preCreateAppointment)
       verify(prisonApiService).postAppointment(offenderBookingId, postCreateAppointment)
 
-      verify(videoLinkBookingRepository).save(
-        booking.copy(
-          id = null,
-          pre = booking.pre?.copy(id = null),
-          main = booking.main.copy(id = null),
-          post = booking.post?.copy(id = null)
-        )
-      )
+      verify(videoLinkBookingRepository).save(makeBooking(null))
     }
   }
 
@@ -493,15 +482,11 @@ class VideoLinkBookingServiceTest {
 
       val theBooking = VideoLinkBooking(
         id = 1L,
-        main = VideoLinkAppointment(
-          id = 2L,
-          bookingId = 30L,
-          appointmentId = 40L,
-          court = "The court",
-          hearingType = HearingType.MAIN,
-          madeByTheCourt = true
-        )
+        offenderBookingId = 30L,
+        courtName = "The court",
+        madeByTheCourt = true
       )
+      theBooking.addMainAppointment(appointmentId = 40L, id = 2L)
 
       whenever(videoLinkBookingRepository.findById(anyLong())).thenReturn(Optional.of(theBooking))
       whenever(prisonApiService.postAppointment(anyLong(), any())).thenReturn(Event(3L, "WRI"))
@@ -529,16 +514,9 @@ class VideoLinkBookingServiceTest {
         )
       )
 
-      val expectedAfterUpdate = VideoLinkBooking(
-        id = 1L,
-        main = VideoLinkAppointment(
-          bookingId = 30L,
-          appointmentId = 3L,
-          court = "The court",
-          hearingType = HearingType.MAIN,
-          madeByTheCourt = true
-        )
-      )
+      val expectedAfterUpdate =
+        VideoLinkBooking(id = 1L, offenderBookingId = 30L, courtName = "The court", madeByTheCourt = true)
+      expectedAfterUpdate.addMainAppointment(3L)
 
       assertThat(theBooking)
         .usingRecursiveComparison()
@@ -574,36 +552,14 @@ class VideoLinkBookingServiceTest {
     fun `Happy flow - update pre, main and post`() {
       val service = service()
 
-      val theBooking = VideoLinkBooking(
-        id = 1L,
-        pre = VideoLinkAppointment(
-          id = 2L,
-          bookingId = 30L,
-          appointmentId = 40L,
-          court = "The court",
-          hearingType = HearingType.PRE,
-          madeByTheCourt = true
-        ),
-        main = VideoLinkAppointment(
-          id = 3L,
-          bookingId = 30L,
-          appointmentId = 41L,
-          court = "The court",
-          hearingType = HearingType.MAIN,
-          madeByTheCourt = true
-        ),
-        post = VideoLinkAppointment(
-          id = 4L,
-          bookingId = 30L,
-          appointmentId = 42L,
-          court = "The court",
-          hearingType = HearingType.POST,
-          madeByTheCourt = true
-        )
-      )
+      val theBooking =
+        VideoLinkBooking(id = 1L, offenderBookingId = 30L, courtName = "The court", madeByTheCourt = true)
+      theBooking.addPreAppointment(appointmentId = 40L, id = 2L)
+      theBooking.addMainAppointment(appointmentId = 41L, id = 3L)
+      theBooking.addPostAppointment(appointmentId = 42L, id = 4L)
 
       whenever(videoLinkBookingRepository.findById(anyLong())).thenReturn(Optional.of(theBooking))
-      whenever(prisonApiService.postAppointment(anyLong(), any())).thenReturn(Event(3L, "WRI"))
+      whenever(prisonApiService.postAppointment(anyLong(), any())).thenReturn(Event(9999L, "WRI"))
 
       service.updateVideoLinkBooking(
         1L,
@@ -667,30 +623,11 @@ class VideoLinkBookingServiceTest {
       assertThat(theBooking)
         .usingRecursiveComparison()
         .isEqualTo(
-          VideoLinkBooking(
-            id = 1L,
-            pre = VideoLinkAppointment(
-              bookingId = 30L,
-              appointmentId = 3L,
-              court = "The court",
-              hearingType = HearingType.PRE,
-              madeByTheCourt = true
-            ),
-            main = VideoLinkAppointment(
-              bookingId = 30L,
-              appointmentId = 3L,
-              court = "The court",
-              hearingType = HearingType.MAIN,
-              madeByTheCourt = true
-            ),
-            post = VideoLinkAppointment(
-              bookingId = 30L,
-              appointmentId = 3L,
-              court = "The court",
-              hearingType = HearingType.POST,
-              madeByTheCourt = true
-            )
-          )
+          VideoLinkBooking(id = 1L, offenderBookingId = 30L, courtName = "The court", madeByTheCourt = true).apply {
+            addPreAppointment(appointmentId = 9999L)
+            addMainAppointment(appointmentId = 9999L)
+            addPostAppointment(appointmentId = 9999L)
+          }
         )
     }
   }
@@ -700,38 +637,14 @@ class VideoLinkBookingServiceTest {
     val service = service()
 
     private val mainAppointmentId = 12L
-    private val mainVideoLinkAppointment = VideoLinkAppointment(
-      id = 222,
-      appointmentId = mainAppointmentId,
-      bookingId = 1,
-      court = COURT_NAME,
-      hearingType = HearingType.MAIN
-    )
-
     private val preAppointmentId = 13L
-    private val preVideoLinkAppointment = VideoLinkAppointment(
-      id = 111,
-      appointmentId = preAppointmentId,
-      bookingId = 1,
-      court = COURT_NAME,
-      hearingType = HearingType.PRE
-    )
-
     private val postAppointmentId = 14L
-    private val postVideoLinkAppointment = VideoLinkAppointment(
-      id = 333,
-      appointmentId = postAppointmentId,
-      bookingId = 1,
-      court = COURT_NAME,
-      hearingType = HearingType.POST
-    )
 
-    private val videoLinkBooking = VideoLinkBooking(
-      pre = preVideoLinkAppointment,
-      main = mainVideoLinkAppointment,
-      post = postVideoLinkAppointment,
-      id = 100
-    )
+    private val videoLinkBooking = VideoLinkBooking(offenderBookingId = 1, courtName = COURT_NAME, id = 100).apply {
+      addPreAppointment(appointmentId = preAppointmentId, id = 111)
+      addMainAppointment(appointmentId = mainAppointmentId, id = 222)
+      addPostAppointment(appointmentId = postAppointmentId, id = 333)
+    }
 
     @Test
     fun `when there is no video link booking it throws an exception`() {
@@ -749,9 +662,9 @@ class VideoLinkBookingServiceTest {
 
       service.deleteVideoLinkBooking(videoLinkBooking.id!!)
 
-      verify(prisonApiService).deleteAppointment(preVideoLinkAppointment.appointmentId)
-      verify(prisonApiService).deleteAppointment(mainVideoLinkAppointment.appointmentId)
-      verify(prisonApiService).deleteAppointment(postVideoLinkAppointment.appointmentId)
+      verify(prisonApiService).deleteAppointment(preAppointmentId)
+      verify(prisonApiService).deleteAppointment(mainAppointmentId)
+      verify(prisonApiService).deleteAppointment(postAppointmentId)
 
       verify(videoLinkBookingRepository).deleteById(videoLinkBooking.id!!)
       verify(videoLinkBookingEventListener).bookingDeleted(videoLinkBooking)
@@ -763,39 +676,15 @@ class VideoLinkBookingServiceTest {
     val service = service()
 
     private val mainAppointmentId = 12L
-    private val mainVideoLinkAppointment = VideoLinkAppointment(
-      id = 222,
-      appointmentId = mainAppointmentId,
-      bookingId = 1,
-      court = COURT_NAME,
-      courtId = COURT_ID,
-      hearingType = HearingType.MAIN
-    )
-
     private val preAppointmentId = 13L
-    private val preVideoLinkAppointment = VideoLinkAppointment(
-      id = 111,
-      appointmentId = preAppointmentId,
-      bookingId = 1,
-      court = COURT_NAME,
-      hearingType = HearingType.PRE
-    )
-
     private val postAppointmentId = 14L
-    private val postVideoLinkAppointment = VideoLinkAppointment(
-      id = 333,
-      appointmentId = postAppointmentId,
-      bookingId = 1,
-      court = COURT_NAME,
-      hearingType = HearingType.POST
-    )
 
-    private val videoLinkBooking = VideoLinkBooking(
-      pre = preVideoLinkAppointment,
-      main = mainVideoLinkAppointment,
-      post = postVideoLinkAppointment,
-      id = 100
-    )
+    private val videoLinkBooking =
+      VideoLinkBooking(offenderBookingId = 1, courtName = COURT_NAME, courtId = COURT_ID, id = 100).apply {
+        addPreAppointment(appointmentId = preAppointmentId, id = 111)
+        addMainAppointment(appointmentId = mainAppointmentId, id = 222)
+        addPostAppointment(appointmentId = postAppointmentId, id = 333)
+      }
 
     private val preAppointment = PrisonAppointment(
       bookingId = 1,
@@ -844,9 +733,9 @@ class VideoLinkBookingServiceTest {
 
       whenever(videoLinkBookingRepository.findById(anyLong())).thenReturn(Optional.of(videoLinkBooking))
 
-      whenever(prisonApiService.getPrisonAppointment(videoLinkBooking.main.appointmentId)).thenReturn(mainAppointment)
-      whenever(prisonApiService.getPrisonAppointment(videoLinkBooking.pre!!.appointmentId)).thenReturn(preAppointment)
-      whenever(prisonApiService.getPrisonAppointment(videoLinkBooking.post!!.appointmentId)).thenReturn(postAppointment)
+      whenever(prisonApiService.getPrisonAppointment(mainAppointmentId)).thenReturn(mainAppointment)
+      whenever(prisonApiService.getPrisonAppointment(preAppointmentId)).thenReturn(preAppointment)
+      whenever(prisonApiService.getPrisonAppointment(postAppointmentId)).thenReturn(postAppointment)
       val result = service.getVideoLinkBooking(videoLinkBooking.id!!)
 
       assertThat(result).isEqualTo(
@@ -854,8 +743,8 @@ class VideoLinkBookingServiceTest {
           videoLinkBookingId = 100,
           bookingId = 1,
           agencyId = "WWI",
-          court = mainVideoLinkAppointment.court!!,
-          courtId = mainVideoLinkAppointment.courtId,
+          court = COURT_NAME,
+          courtId = COURT_ID,
           comment = "any comment",
           pre = VideoLinkBookingResponse.LocationTimeslot(
             locationId = preAppointment.eventLocationId,
@@ -879,17 +768,17 @@ class VideoLinkBookingServiceTest {
     @Test
     fun `when there is a video link booking with main appointment only`() {
       whenever(videoLinkBookingRepository.findById(anyLong())).thenReturn(Optional.of(videoLinkBooking))
-      whenever(prisonApiService.getPrisonAppointment(videoLinkBooking.main.appointmentId)).thenReturn(mainAppointment)
-      whenever(prisonApiService.getPrisonAppointment(videoLinkBooking.pre!!.appointmentId)).thenReturn(null)
-      whenever(prisonApiService.getPrisonAppointment(videoLinkBooking.post!!.appointmentId)).thenReturn(null)
+      whenever(prisonApiService.getPrisonAppointment(mainAppointmentId)).thenReturn(mainAppointment)
+      whenever(prisonApiService.getPrisonAppointment(preAppointmentId)).thenReturn(null)
+      whenever(prisonApiService.getPrisonAppointment(postAppointmentId)).thenReturn(null)
       val result = service.getVideoLinkBooking(videoLinkBooking.id!!)
       assertThat(result).isEqualTo(
         VideoLinkBookingResponse(
           videoLinkBookingId = 100,
           bookingId = 1,
           agencyId = "WWI",
-          court = mainVideoLinkAppointment.court!!,
-          courtId = mainVideoLinkAppointment.courtId,
+          court = COURT_NAME,
+          courtId = COURT_ID,
           comment = "any comment",
           main = VideoLinkBookingResponse.LocationTimeslot(
             locationId = mainAppointment.eventLocationId,
@@ -903,9 +792,9 @@ class VideoLinkBookingServiceTest {
     @Test
     fun `when there is a video link booking with pre and post appointments and no main appointment`() {
       whenever(videoLinkBookingRepository.findById(anyLong())).thenReturn(Optional.of(videoLinkBooking))
-      whenever(prisonApiService.getPrisonAppointment(videoLinkBooking.main.appointmentId)).thenReturn(null)
-      whenever(prisonApiService.getPrisonAppointment(videoLinkBooking.pre!!.appointmentId)).thenReturn(preAppointment)
-      whenever(prisonApiService.getPrisonAppointment(videoLinkBooking.post!!.appointmentId)).thenReturn(postAppointment)
+      whenever(prisonApiService.getPrisonAppointment(mainAppointmentId)).thenReturn(null)
+      whenever(prisonApiService.getPrisonAppointment(preAppointmentId)).thenReturn(preAppointment)
+      whenever(prisonApiService.getPrisonAppointment(postAppointmentId)).thenReturn(postAppointment)
       Assertions.assertThrows(EntityNotFoundException::class.java) {
         service.getVideoLinkBooking(videoLinkBooking.id!!)
       }
@@ -920,7 +809,9 @@ class VideoLinkBookingServiceTest {
     @Test
     fun `no prison appointments, no VLBs`() {
       whenever(prisonApiService.getScheduledAppointments(anyString(), any())).thenReturn(listOf())
-      whenever(videoLinkBookingRepository.findByMainAppointmentIds(any())).thenReturn(listOf())
+      whenever(
+        videoLinkBookingRepository.findByAppointmentIdsAndHearingType(any(), eq(HearingType.MAIN))
+      ).thenReturn(listOf())
 
       val bookings = service.getVideoLinkBookingsForPrisonAndDateAndCourt("WWI", date, null, null)
       assertThat(bookings).isEmpty()
@@ -935,7 +826,7 @@ class VideoLinkBookingServiceTest {
             scheduledAppointments("VLB", "WWI", 1000, 1010) +
             scheduledAppointments("VLB", "WWI", 2000, 2010)
         )
-      whenever(videoLinkBookingRepository.findByMainAppointmentIds(any()))
+      whenever(videoLinkBookingRepository.findByAppointmentIdsAndHearingType(any(), eq(HearingType.MAIN)))
         .thenReturn(videoLinkBookings("Wimbledon", null, 1, 10))
 
       val bookings = service.getVideoLinkBookingsForPrisonAndDateAndCourt("WWI", date, null, null)
@@ -954,12 +845,13 @@ class VideoLinkBookingServiceTest {
           tuple(1010L, 2010L, 3010L),
         )
 
-      verify(videoLinkBookingRepository).findByMainAppointmentIds(
+      verify(videoLinkBookingRepository).findByAppointmentIdsAndHearingType(
         rangesAsList(
           (1L..10L),
           (1000L..1010L),
           (2000L..2010L)
-        )
+        ),
+        HearingType.MAIN
       )
     }
 
@@ -971,7 +863,7 @@ class VideoLinkBookingServiceTest {
         .thenReturn(
           scheduledAppointments("VLB", "WWI", 1, 10)
         )
-      whenever(videoLinkBookingRepository.findByMainAppointmentIds(any()))
+      whenever(videoLinkBookingRepository.findByAppointmentIdsAndHearingType(any(), eq(HearingType.MAIN)))
         .thenReturn(
           videoLinkBookings("Wimbledon", null, 1, 5) +
             videoLinkBookings("Windsor", null, 6, 10)
@@ -988,7 +880,7 @@ class VideoLinkBookingServiceTest {
         .thenReturn(
           scheduledAppointments("VLB", "WWI", 1, 10)
         )
-      whenever(videoLinkBookingRepository.findByMainAppointmentIds(any()))
+      whenever(videoLinkBookingRepository.findByAppointmentIdsAndHearingType(any(), eq(HearingType.MAIN)))
         .thenReturn(
           videoLinkBookings("Wimbledon", "WIM", 1, 5) +
             videoLinkBookings("Windsor", "WIN", 6, 10)
@@ -1004,7 +896,7 @@ class VideoLinkBookingServiceTest {
     fun `happy flow - filter appointment type`() {
       whenever(prisonApiService.getScheduledAppointments(anyString(), any()))
         .thenReturn(scheduledAppointments("NOWT", "WWI", 1, 10))
-      whenever(videoLinkBookingRepository.findByMainAppointmentIds(any()))
+      whenever(videoLinkBookingRepository.findByAppointmentIdsAndHearingType(any(), eq(HearingType.MAIN)))
         .thenReturn(videoLinkBookings("Wimbledon", null, 1, 10))
 
       val bookings = service.getVideoLinkBookingsForPrisonAndDateAndCourt("WWI", date, null, null)
@@ -1045,33 +937,19 @@ class VideoLinkBookingServiceTest {
             )
           )
         )
-      whenever(videoLinkBookingRepository.findByMainAppointmentIds(any()))
+
+      whenever(videoLinkBookingRepository.findByAppointmentIdsAndHearingType(any(), eq(HearingType.MAIN)))
         .thenReturn(
           listOf(
             VideoLinkBooking(
               id = 1000L,
-              pre = VideoLinkAppointment(
-                id = 10001,
-                bookingId = 1000,
-                appointmentId = 1001,
-                court = "Wimbledon",
-                hearingType = HearingType.PRE
-              ),
-              main = VideoLinkAppointment(
-                id = 20000,
-                bookingId = 1000,
-                appointmentId = 1002,
-                court = "Wimbledon",
-                hearingType = HearingType.MAIN
-              ),
-              post = VideoLinkAppointment(
-                id = 30000,
-                bookingId = 1000,
-                appointmentId = 1003,
-                court = "Wimbledon",
-                hearingType = HearingType.POST
-              )
-            )
+              offenderBookingId = 1000,
+              courtName = "Wimbledon"
+            ).apply {
+              addPreAppointment(id = 10001, appointmentId = 1001)
+              addMainAppointment(id = 20000, appointmentId = 1002)
+              addPostAppointment(id = 30000, appointmentId = 1003)
+            }
           )
         )
 
@@ -1116,33 +994,14 @@ class VideoLinkBookingServiceTest {
             )
           )
         )
-      whenever(videoLinkBookingRepository.findByMainAppointmentIds(any()))
+      whenever(videoLinkBookingRepository.findByAppointmentIdsAndHearingType(any(), eq(HearingType.MAIN)))
         .thenReturn(
           listOf(
-            VideoLinkBooking(
-              id = 1000L,
-              pre = VideoLinkAppointment(
-                id = 10001,
-                bookingId = 1000,
-                appointmentId = 1001,
-                court = "Wimbledon",
-                hearingType = HearingType.PRE
-              ),
-              main = VideoLinkAppointment(
-                id = 20000,
-                bookingId = 1000,
-                appointmentId = 1002,
-                court = "Wimbledon",
-                hearingType = HearingType.MAIN
-              ),
-              post = VideoLinkAppointment(
-                id = 30000,
-                bookingId = 1000,
-                appointmentId = 1003,
-                court = "Wimbledon",
-                hearingType = HearingType.POST
-              )
-            )
+            VideoLinkBooking(id = 1000L, offenderBookingId = 1000, courtName = "Wimbledon").apply {
+              addPreAppointment(id = 10001, appointmentId = 1001)
+              addMainAppointment(id = 20000, appointmentId = 1002)
+              addPostAppointment(id = 30000, appointmentId = 1003)
+            }
           )
         )
 
@@ -1162,30 +1021,11 @@ class VideoLinkBookingServiceTest {
       whenever(videoLinkBookingRepository.findById(1L))
         .thenReturn(
           Optional.of(
-            VideoLinkBooking(
-              id = 1L,
-              pre = VideoLinkAppointment(
-                id = 100L,
-                appointmentId = 10L,
-                bookingId = 999L,
-                hearingType = HearingType.PRE,
-                court = "The Court"
-              ),
-              main = VideoLinkAppointment(
-                id = 101L,
-                appointmentId = 11L,
-                bookingId = 999L,
-                hearingType = HearingType.MAIN,
-                court = "The Court"
-              ),
-              post = VideoLinkAppointment(
-                id = 102L,
-                appointmentId = 12L,
-                bookingId = 999L,
-                hearingType = HearingType.POST,
-                court = "The Court"
-              ),
-            )
+            VideoLinkBooking(id = 1L, offenderBookingId = 999L, courtName = "The Court").apply {
+              addPreAppointment(id = 100L, appointmentId = 10L)
+              addMainAppointment(id = 101L, appointmentId = 11L)
+              addPostAppointment(id = 102L, appointmentId = 12L)
+            }
           )
         )
 
@@ -1205,16 +1045,9 @@ class VideoLinkBookingServiceTest {
       whenever(videoLinkBookingRepository.findById(1L))
         .thenReturn(
           Optional.of(
-            VideoLinkBooking(
-              id = 1L,
-              main = VideoLinkAppointment(
-                id = 101L,
-                appointmentId = 11L,
-                bookingId = 999L,
-                hearingType = HearingType.MAIN,
-                court = "The Court"
-              ),
-            )
+            VideoLinkBooking(id = 1L, offenderBookingId = 999L, courtName = "The Court").apply {
+              addMainAppointment(id = 101L, appointmentId = 11L)
+            }
           )
         )
 
@@ -1279,33 +1112,11 @@ class VideoLinkBookingServiceTest {
       lastAppointmentId: Long = 30L
     ): List<VideoLinkBooking> =
       (firstAppointmentId..lastAppointmentId).map {
-        VideoLinkBooking(
-          id = it + 1000L,
-          pre = VideoLinkAppointment(
-            id = it + 10000,
-            bookingId = it + 1000,
-            appointmentId = it + 1000,
-            court = court,
-            courtId = courtId,
-            hearingType = HearingType.PRE
-          ),
-          main = VideoLinkAppointment(
-            id = it + 20000,
-            bookingId = it + 1000,
-            appointmentId = it,
-            court = court,
-            courtId = courtId,
-            hearingType = HearingType.MAIN
-          ),
-          post = VideoLinkAppointment(
-            id = it + 30000,
-            bookingId = it + 1000,
-            appointmentId = it + 2000,
-            court = court,
-            courtId = courtId,
-            hearingType = HearingType.POST
-          )
-        )
+        VideoLinkBooking(id = it + 1000L, offenderBookingId = it + 1000, courtName = court, courtId = courtId).apply {
+          addPreAppointment(id = it + 10000, appointmentId = it + 1000)
+          addMainAppointment(id = it + 20000, appointmentId = it)
+          addPostAppointment(id = it + 30000, appointmentId = it + 2000)
+        }
       }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/court/VideoLinkBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/court/VideoLinkBookingServiceTest.kt
@@ -59,7 +59,7 @@ class VideoLinkBookingServiceTest {
   }
 
   @Test
-  fun `should return NO video link appointments`() {
+  fun `Should return NO video link appointments`() {
     val service = service()
     val appointments = service.getVideoLinkAppointments(setOf(1, 2))
 
@@ -68,7 +68,7 @@ class VideoLinkBookingServiceTest {
   }
 
   @Test
-  fun `should return and map video link appointments`() {
+  fun `Should return and map video link appointments`() {
     whenever(videoLinkAppointmentRepository.findVideoLinkAppointmentByAppointmentIdIn(setOf(3, 4))).thenReturn(
       setOf(
         VideoLinkAppointment(
@@ -125,7 +125,7 @@ class VideoLinkBookingServiceTest {
     }
 
     @Test
-    fun `happy flow - Main appointment only - madeByTheCourt`() {
+    fun `Happy path - Main appointment only - madeByTheCourt`() {
 
       fun makeBooking(id: Long?) = VideoLinkBooking(
         id = id,
@@ -364,7 +364,7 @@ class VideoLinkBookingServiceTest {
     }
 
     @Test
-    fun `happy flow - pre, main and post appointments - Not madeByTheCourt`() {
+    fun `Happy path - pre, main and post appointments - Not madeByTheCourt`() {
 
       val offenderBookingId = 1L
 
@@ -477,7 +477,7 @@ class VideoLinkBookingServiceTest {
     }
 
     @Test
-    fun `Happy flow - update main`() {
+    fun `Happy path - update main`() {
       val service = service()
 
       val theBooking = VideoLinkBooking(
@@ -549,7 +549,7 @@ class VideoLinkBookingServiceTest {
     }
 
     @Test
-    fun `Happy flow - update pre, main and post`() {
+    fun `Happy path - update pre, main and post`() {
       val service = service()
 
       val theBooking =
@@ -647,7 +647,7 @@ class VideoLinkBookingServiceTest {
     }
 
     @Test
-    fun `when there is no video link booking it throws an exception`() {
+    fun `Wen there is no video link booking it throws an exception`() {
 
       whenever(videoLinkBookingRepository.findById(anyLong())).thenReturn(Optional.empty())
       Assertions.assertThrows(EntityNotFoundException::class.java) {
@@ -656,7 +656,7 @@ class VideoLinkBookingServiceTest {
     }
 
     @Test
-    fun `happy path`() {
+    fun `Happy path`() {
 
       whenever(videoLinkBookingRepository.findById(anyLong())).thenReturn(Optional.of(videoLinkBooking))
 
@@ -720,7 +720,7 @@ class VideoLinkBookingServiceTest {
     )
 
     @Test
-    fun `when there is no video link booking it throws an exception`() {
+    fun `When there is no video link booking it throws an exception`() {
 
       whenever(videoLinkBookingRepository.findById(anyLong())).thenReturn(Optional.empty())
       Assertions.assertThrows(EntityNotFoundException::class.java) {
@@ -729,7 +729,7 @@ class VideoLinkBookingServiceTest {
     }
 
     @Test
-    fun `when there is a video link booking with pre, main and post`() {
+    fun `When there is a video link booking with pre, main and post`() {
 
       whenever(videoLinkBookingRepository.findById(anyLong())).thenReturn(Optional.of(videoLinkBooking))
 
@@ -766,7 +766,7 @@ class VideoLinkBookingServiceTest {
     }
 
     @Test
-    fun `when there is a video link booking with main appointment only`() {
+    fun `When there is a video link booking with main appointment only`() {
       whenever(videoLinkBookingRepository.findById(anyLong())).thenReturn(Optional.of(videoLinkBooking))
       whenever(prisonApiService.getPrisonAppointment(mainAppointmentId)).thenReturn(mainAppointment)
       whenever(prisonApiService.getPrisonAppointment(preAppointmentId)).thenReturn(null)
@@ -790,7 +790,7 @@ class VideoLinkBookingServiceTest {
     }
 
     @Test
-    fun `when there is a video link booking with pre and post appointments and no main appointment`() {
+    fun `When there is a video link booking with pre and post appointments and no main appointment`() {
       whenever(videoLinkBookingRepository.findById(anyLong())).thenReturn(Optional.of(videoLinkBooking))
       whenever(prisonApiService.getPrisonAppointment(mainAppointmentId)).thenReturn(null)
       whenever(prisonApiService.getPrisonAppointment(preAppointmentId)).thenReturn(preAppointment)
@@ -807,7 +807,7 @@ class VideoLinkBookingServiceTest {
     val date: LocalDate = LocalDate.of(2020, 12, 25)
 
     @Test
-    fun `no prison appointments, no VLBs`() {
+    fun `No prison appointments, no VLBs`() {
       whenever(prisonApiService.getScheduledAppointments(anyString(), any())).thenReturn(listOf())
       whenever(
         videoLinkBookingRepository.findByAppointmentIdsAndHearingType(any(), eq(HearingType.MAIN))
@@ -819,12 +819,13 @@ class VideoLinkBookingServiceTest {
     }
 
     @Test
-    fun `happy flow`() {
+    fun `Happy path`() {
       whenever(prisonApiService.getScheduledAppointments(anyString(), any()))
         .thenReturn(
           scheduledAppointments("VLB", "WWI", 1, 10) +
             scheduledAppointments("VLB", "WWI", 1000, 1010) +
-            scheduledAppointments("VLB", "WWI", 2000, 2010)
+            scheduledAppointments("VLB", "WWI", 2000, 2010) +
+            scheduledAppointments("XXX", "WWI", 3000, 3010)
         )
       whenever(videoLinkBookingRepository.findByAppointmentIdsAndHearingType(any(), eq(HearingType.MAIN)))
         .thenReturn(videoLinkBookings("Wimbledon", null, 1, 10))
@@ -858,11 +859,12 @@ class VideoLinkBookingServiceTest {
     private fun rangesAsList(vararg ranges: LongRange) = ranges.asList().flatMap { range -> range.map { it } }
 
     @Test
-    fun `happy flow - filter by court`() {
+    fun `Happy path - filter by court`() {
       whenever(prisonApiService.getScheduledAppointments(anyString(), any()))
         .thenReturn(
           scheduledAppointments("VLB", "WWI", 1, 10)
         )
+
       whenever(videoLinkBookingRepository.findByAppointmentIdsAndHearingType(any(), eq(HearingType.MAIN)))
         .thenReturn(
           videoLinkBookings("Wimbledon", null, 1, 5) +
@@ -875,7 +877,7 @@ class VideoLinkBookingServiceTest {
     }
 
     @Test
-    fun `happy flow - filter by courtId`() {
+    fun `Happy path - filter by courtId`() {
       whenever(prisonApiService.getScheduledAppointments(anyString(), any()))
         .thenReturn(
           scheduledAppointments("VLB", "WWI", 1, 10)
@@ -893,18 +895,20 @@ class VideoLinkBookingServiceTest {
     }
 
     @Test
-    fun `happy flow - filter appointment type`() {
+    fun `Happy path - filter appointment type`() {
       whenever(prisonApiService.getScheduledAppointments(anyString(), any()))
         .thenReturn(scheduledAppointments("NOWT", "WWI", 1, 10))
-      whenever(videoLinkBookingRepository.findByAppointmentIdsAndHearingType(any(), eq(HearingType.MAIN)))
-        .thenReturn(videoLinkBookings("Wimbledon", null, 1, 10))
 
-      val bookings = service.getVideoLinkBookingsForPrisonAndDateAndCourt("WWI", date, null, null)
-      assertThat(bookings).isEmpty()
+      whenever(videoLinkBookingRepository.findByAppointmentIdsAndHearingType(any(), eq(HearingType.MAIN)))
+        .thenReturn(emptyList())
+
+      service.getVideoLinkBookingsForPrisonAndDateAndCourt("WWI", date, null, null)
+
+      verify(videoLinkBookingRepository).findByAppointmentIdsAndHearingType(emptyList(), HearingType.MAIN)
     }
 
     @Test
-    fun `appointments with missing end times are filtered out`() {
+    fun `Appointments with missing end times are filtered out`() {
       whenever(prisonApiService.getScheduledAppointments(anyString(), any()))
         .thenReturn(
           listOf(
@@ -959,62 +963,13 @@ class VideoLinkBookingServiceTest {
       assertThat(bookings[0].main).isNotNull
       assertThat(bookings[0].post).isNull()
     }
-
-    @Test
-    fun `bookings with with missing end times on main appointment are filtered out entirely`() {
-      whenever(prisonApiService.getScheduledAppointments(anyString(), any()))
-        .thenReturn(
-          listOf(
-            ScheduledAppointmentDto(
-              id = 1001,
-              agencyId = "WEI",
-              locationId = 1001,
-              appointmentTypeCode = "VLB",
-              startTime = LocalDateTime.of(2020, 1, 1, 9, 40),
-              endTime = LocalDateTime.of(2020, 1, 1, 10, 0),
-              offenderNo = "A1234AA"
-            ),
-            ScheduledAppointmentDto(
-              id = 1002,
-              agencyId = "WEI",
-              locationId = 1002,
-              appointmentTypeCode = "VLB",
-              startTime = LocalDateTime.of(2020, 1, 1, 10, 0),
-              endTime = null,
-              offenderNo = "B2345BB"
-            ),
-            ScheduledAppointmentDto(
-              id = 1003,
-              agencyId = "WEI",
-              locationId = 1003,
-              appointmentTypeCode = "VLB",
-              startTime = LocalDateTime.of(2020, 1, 1, 10, 30),
-              endTime = null,
-              offenderNo = "C3456CC"
-            )
-          )
-        )
-      whenever(videoLinkBookingRepository.findByAppointmentIdsAndHearingType(any(), eq(HearingType.MAIN)))
-        .thenReturn(
-          listOf(
-            VideoLinkBooking(id = 1000L, offenderBookingId = 1000, courtName = "Wimbledon").apply {
-              addPreAppointment(id = 10001, appointmentId = 1001)
-              addMainAppointment(id = 20000, appointmentId = 1002)
-              addPostAppointment(id = 30000, appointmentId = 1003)
-            }
-          )
-        )
-
-      val bookings = service.getVideoLinkBookingsForPrisonAndDateAndCourt("WWI", date, "Wimbledon", null)
-      assertThat(bookings).isEmpty()
-    }
   }
 
   @Nested
   inner class UpdateVideoLinkBookingComment {
 
     @Test
-    fun `Happy flow - Pre, main and post appointments`() {
+    fun `Happy path - Pre, main and post appointments`() {
       val service = service()
       val newComment = "New comment"
 
@@ -1038,7 +993,7 @@ class VideoLinkBookingServiceTest {
     }
 
     @Test
-    fun `Happy flow - main appointment only, no comment`() {
+    fun `Happy path - main appointment only, no comment`() {
       val service = service()
       val newComment = ""
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/locationfinder/AppointmentLocationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/locationfinder/AppointmentLocationsServiceTest.kt
@@ -11,8 +11,6 @@ import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.anyList
 import org.mockito.ArgumentMatchers.anyString
 import uk.gov.justice.digital.hmpps.whereabouts.dto.prisonapi.ScheduledAppointmentDto
-import uk.gov.justice.digital.hmpps.whereabouts.model.HearingType
-import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkAppointment
 import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkBooking
 import uk.gov.justice.digital.hmpps.whereabouts.repository.VideoLinkBookingRepository
 import uk.gov.justice.digital.hmpps.whereabouts.services.PrisonApiService
@@ -229,45 +227,14 @@ class AppointmentLocationsServiceTest {
     whenever(videoLinkBookingRepository.findAllById(anyList()))
       .thenReturn(
         listOf(
-          VideoLinkBooking(
-            id = 1L,
-            main = VideoLinkAppointment(
-              appointmentId = 1L,
-              id = 1L,
-              bookingId = 9999L,
-              court = "Don't care",
-              courtId = "XXXX",
-              hearingType = HearingType.MAIN
-            )
-          ),
-          VideoLinkBooking(
-            id = 2L,
-            main = VideoLinkAppointment(
-              appointmentId = 10L,
-              id = 2L,
-              bookingId = 9999L,
-              court = "Don't care",
-              courtId = "XXXX",
-              hearingType = HearingType.MAIN
-            ),
-            pre = VideoLinkAppointment(
-              appointmentId = 3L,
-              id = 3L,
-              bookingId = 9999L,
-              court = "Don't care",
-              courtId = "XXXX",
-              hearingType = HearingType.PRE
-            ),
-            post = VideoLinkAppointment(
-              appointmentId = 4L,
-              id = 4L,
-              bookingId = 9999L,
-              court = "Don't care",
-              courtId = "XXXX",
-              hearingType = HearingType.POST
-            ),
-          )
-
+          VideoLinkBooking(id = 1L, offenderBookingId = 9999L, courtName = "Don't care", courtId = "XXXX").apply {
+            addMainAppointment(id = 1L, appointmentId = 1L)
+          },
+          VideoLinkBooking(id = 2L, offenderBookingId = 9999L, courtName = "Don't care", courtId = "XXXX").apply {
+            addMainAppointment(id = 2L, appointmentId = 10L)
+            addPreAppointment(id = 3L, appointmentId = 3L)
+            addPostAppointment(id = 4L, appointmentId = 4L)
+          }
         )
       )
 
@@ -305,7 +272,9 @@ class AppointmentLocationsServiceTest {
 
   @Test
   fun `it translates LocationsForAppointmentIntervals to AvaliableLocations`() {
-    whenever(prisonApiService.getScheduledAppointments(anyString(), any(), anyOrNull(), anyOrNull())).thenReturn(emptyList())
+    whenever(prisonApiService.getScheduledAppointments(anyString(), any(), anyOrNull(), anyOrNull())).thenReturn(
+      emptyList()
+    )
 
     whenever(prisonApiService.getAgencyLocationsForTypeUnrestricted(anyString(), anyString()))
       .thenReturn(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/utils/DataHelpers.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/utils/DataHelpers.kt
@@ -5,9 +5,7 @@ import uk.gov.justice.digital.hmpps.whereabouts.dto.AppointmentDefaults
 import uk.gov.justice.digital.hmpps.whereabouts.dto.CreateAppointmentSpecification
 import uk.gov.justice.digital.hmpps.whereabouts.dto.CreatePrisonAppointment
 import uk.gov.justice.digital.hmpps.whereabouts.dto.Repeat
-import uk.gov.justice.digital.hmpps.whereabouts.model.HearingType
 import uk.gov.justice.digital.hmpps.whereabouts.model.PrisonAppointment
-import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkAppointment
 import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkBooking
 import java.time.LocalDateTime
 
@@ -15,41 +13,12 @@ class DataHelpers {
 
   companion object {
 
-    fun makeVideoLinkBooking(
-      id: Long,
-      main: VideoLinkAppointment = makeVideoLinkAppointment(
-        id = 1L,
-        appointmentId = 1L,
-        hearingType = HearingType.MAIN
-      ),
-      pre: VideoLinkAppointment = makeVideoLinkAppointment(id = 2L, appointmentId = 2L, hearingType = HearingType.PRE),
-      post: VideoLinkAppointment = makeVideoLinkAppointment(id = 3L, appointmentId = 3L, hearingType = HearingType.POST)
-    ): VideoLinkBooking = VideoLinkBooking(
-      id = id,
-      main = main,
-      pre = pre,
-      post = post
-    )
-
-    fun makeVideoLinkAppointment(
-      id: Long,
-      bookingId: Long = -1L,
-      appointmentId: Long,
-      court: String? = "Court 1",
-      courtId: String? = "TSTCRT",
-      hearingType: HearingType,
-      createdByUsername: String = "SA",
-      madeByTheCourt: Boolean = true
-    ): VideoLinkAppointment = VideoLinkAppointment(
-      id = id,
-      bookingId = bookingId,
-      appointmentId = appointmentId,
-      court = court,
-      courtId = courtId,
-      hearingType = hearingType,
-      createdByUsername = createdByUsername,
-      madeByTheCourt = madeByTheCourt
-    )
+    fun makeVideoLinkBooking(id: Long): VideoLinkBooking =
+      VideoLinkBooking(id = id, offenderBookingId = -1L, courtName = "Court 1", createdByUsername = "SA").apply {
+        addMainAppointment(id = 1L, appointmentId = 1L)
+        addPreAppointment(id = 2L, appointmentId = 2L)
+        addPostAppointment(id = 3L, appointmentId = 3L)
+      }
 
     fun makeCreatePrisonAppointment(
       appointmentId: Long,


### PR DESCRIPTION
* Move `bookingId`, `court`, `courtId`, `madeByTheCourt` and `createdByUsername` from child table `video_link_appointment` to the parent table `video_link_booking`.
* `video_link_booking` columns renamed for clarity: `court` -> `courtName`, `booking_id` -> `offender_booking_id`.
* Move data from child to parent.
* Drop child columns.
* Invert the links between `video_link_booking` and `video_link_appointment`: 
  * add `video_link_booking_id` to `video_link_appointment` table. (FK to `video_link_booking` `id` column). 
  * Populate `video_link_booking_id` column using values in `video_link_booking` (`pre`, `main`, `post`)
  * drop `main`, `pre` and `post` columns (and FK relationships to `video_link_appointment`)
  * Add database constraints where appropriate
  * Align `VideoLinkBooking` and `VideoLinkAppointment` entities with changes to tables: ManyToOne from VLA to VLB and OneToMany in opposite direction.  OneToMany is a `Map<HearingType, VideoLinkAppointment>`
* Revise repositories, services and tests to align with changes to entities.
* Improve the `VideoLinkBookingRepository` `findByAppointmentIdsAndHearingType` function. Eliminate n+1 select problem, add optional filter by `courtName` and / or `courtId`
* Remove unnecessary filtering from `VideoLinkBookingService` `getVideoLinkBookingsForPrisonAndDateAndCourt` method (now done by db query) filter prison appointments to exclude missing end-dates immediately after retrieving them.