### PR TITLE
DCS-1057 db migration script to assign court_id to booking events

### DIFF
--- a/src/main/resources/db/migration/V29__add_court_id_data_to_video_link_booking_event.sql
+++ b/src/main/resources/db/migration/V29__add_court_id_data_to_video_link_booking_event.sql
@@ -1,0 +1,9 @@
+UPDATE video_link_booking_event vlbe
+   SET court_id=(
+       SELECT vlb.court_id
+         FROM video_link_booking vlb
+        WHERE vlb.id = vlbe.video_link_booking_id
+       )
+ WHERE vlbe.court_id IS NULL
+       AND vlbe.event_type = 'CREATE' ;
+


### PR DESCRIPTION
Assigning court_id will ensure CSV for reports and data studio will be more accurate.
There will be some anomalies where 'null' records will be in the outputs but that is because some records may have been created and then deleted. 