### PR TITLE
DCS-1057 Fix court_ids in video_link_booking_event data.

### DIFF
--- a/src/main/resources/db/migration/V30__add_court_id_data_to_video_link_booking_event.sql
+++ b/src/main/resources/db/migration/V30__add_court_id_data_to_video_link_booking_event.sql
@@ -1,0 +1,8 @@
+update video_link_booking_event vlbe
+   set court_id = (
+       select id
+         from enabled_court ec
+        where vlbe.court = ec.name
+       )
+ where vlbe.court_id is null;
+


### PR DESCRIPTION
join on to enabled_courts by court name.  Matches a number of records where the original video_link_booking had been deleted,