### PR TITLE
DCS-976 Minor refinement to video link booking event reporting

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/repository/VideoLinkBookingEventRepository.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/repository/VideoLinkBookingEventRepository.kt
@@ -19,13 +19,13 @@ interface VideoLinkBookingEventRepository : JpaRepository<VideoLinkBookingEvent,
       QueryHint(name = HINT_READONLY, value = "true")
     ]
   )
-  fun findByTimestampBetween(start: LocalDateTime, end: LocalDateTime): Stream<VideoLinkBookingEvent>
+  fun findByTimestampBetweenOrderByEventId(start: LocalDateTime, end: LocalDateTime): Stream<VideoLinkBookingEvent>
 }
 
 fun VideoLinkBookingEventRepository.findByDatesBetween(
   start: LocalDate,
   end: LocalDate
-): Stream<VideoLinkBookingEvent> = findByTimestampBetween(
+): Stream<VideoLinkBookingEvent> = findByTimestampBetweenOrderByEventId(
   start.atStartOfDay(),
   end.plusDays(1).atStartOfDay().minusSeconds(1)
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/court/VideoLinkBookingEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/court/VideoLinkBookingEventServiceTest.kt
@@ -42,7 +42,7 @@ class VideoLinkBookingEventServiceTest {
       )
     )
 
-    whenever(videoLinkBookingEventRepository.findByTimestampBetween(any(), any())).thenReturn(eventStream)
+    whenever(videoLinkBookingEventRepository.findByTimestampBetweenOrderByEventId(any(), any())).thenReturn(eventStream)
     whenever(courtsService.getCourtNameForCourtId("EYI")).thenReturn("Elmley")
 
     val events = service.getEventsAsCSV(LocalDate.of(2021, Month.JUNE, 1), 7L)
@@ -65,7 +65,7 @@ class VideoLinkBookingEventServiceTest {
       )
     )
 
-    whenever(videoLinkBookingEventRepository.findByTimestampBetween(any(), any())).thenReturn(eventStream)
+    whenever(videoLinkBookingEventRepository.findByTimestampBetweenOrderByEventId(any(), any())).thenReturn(eventStream)
 
     val events = service.getEventsAsCSV(LocalDate.of(2021, Month.JUNE, 1), 7L)
 
@@ -84,7 +84,7 @@ class VideoLinkBookingEventServiceTest {
       )
     )
 
-    whenever(videoLinkBookingEventRepository.findByTimestampBetween(any(), any())).thenReturn(eventStream)
+    whenever(videoLinkBookingEventRepository.findByTimestampBetweenOrderByEventId(any(), any())).thenReturn(eventStream)
     whenever(courtsService.getCourtNameForCourtId("EYI")).thenReturn(null)
 
     val events = service.getEventsAsCSV(LocalDate.of(2021, Month.JUNE, 1), 7L)
@@ -103,7 +103,7 @@ class VideoLinkBookingEventServiceTest {
       )
     )
 
-    whenever(videoLinkBookingEventRepository.findByTimestampBetween(any(), any())).thenReturn(eventStream)
+    whenever(videoLinkBookingEventRepository.findByTimestampBetweenOrderByEventId(any(), any())).thenReturn(eventStream)
 
     val events = service.getEventsAsCSV(LocalDate.of(2021, Month.JUNE, 1), 7L)
 


### PR DESCRIPTION
Add a sort to the VideoLinkBookingEvent query. Ensures that values always come back in the same order.