### PR TITLE
DCS-1063 Change PUT /court/video-link-bookings/{videoBookingId} to make courtId mandatory

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/dto/VideoLinkBookingSpecification.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/dto/VideoLinkBookingSpecification.kt
@@ -36,7 +36,7 @@ data class VideoLinkBookingSpecification(
   override val comment: String? = null,
 
   @ApiModelProperty(value = "Pre-hearing appointment")
-  @Valid
+  @field:Valid
   override val pre: VideoLinkAppointmentSpecification? = null,
 
   @ApiModelProperty(value = "Main appointment", required = true)
@@ -44,6 +44,6 @@ data class VideoLinkBookingSpecification(
   override val main: VideoLinkAppointmentSpecification,
 
   @ApiModelProperty(value = "Post-hearing appointment")
-  @Valid
+  @field:Valid
   override val post: VideoLinkAppointmentSpecification? = null
 ) : VideoLinkAppointmentsSpecification

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/dto/VideoLinkBookingUpdateSpecification.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/dto/VideoLinkBookingUpdateSpecification.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.whereabouts.dto
 
 import io.swagger.annotations.ApiModelProperty
 import javax.validation.Valid
+import javax.validation.constraints.NotEmpty
 
 data class VideoLinkBookingUpdateSpecification(
 
@@ -10,13 +11,14 @@ data class VideoLinkBookingUpdateSpecification(
     example = "CMBGMC",
     required = false,
   )
-  val courtId: String? = null,
+  @field:NotEmpty
+  val courtId: String,
 
   @ApiModelProperty(value = "Free text comments", example = "Requires special access")
   override val comment: String? = null,
 
   @ApiModelProperty(value = "Pre-hearing appointment")
-  @Valid
+  @field:Valid
   override val pre: VideoLinkAppointmentSpecification? = null,
 
   @ApiModelProperty(value = "Main appointment", required = true)
@@ -24,6 +26,6 @@ data class VideoLinkBookingUpdateSpecification(
   override val main: VideoLinkAppointmentSpecification,
 
   @ApiModelProperty(value = "Post-hearing appointment")
-  @Valid
+  @field:Valid
   override val post: VideoLinkAppointmentSpecification? = null
 ) : VideoLinkAppointmentsSpecification

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/VideoLinkBookingService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/VideoLinkBookingService.kt
@@ -87,10 +87,8 @@ class VideoLinkBookingService(
     val (mainEvent, preEvent, postEvent) = createPrisonAppointments(booking.offenderBookingId, specification)
 
     with(booking) {
-      if (specification.courtId != null) {
-        courtName = null
-        courtId = specification.courtId
-      }
+      courtName = null
+      courtId = specification.courtId
       /**
        * Call flush() to persuade Hibernate to remove the old appointments (if any).
        * Have to do this manually because Hibernate doesn't delete the old appointments before attempting

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/dto/VideoLinkBookingSpecificationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/dto/VideoLinkBookingSpecificationTest.kt
@@ -1,0 +1,63 @@
+package uk.gov.justice.digital.hmpps.whereabouts.dto
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import javax.validation.Validation
+import javax.validation.Validator
+
+class VideoLinkBookingSpecificationTest {
+  private val validator: Validator = Validation.buildDefaultValidatorFactory().validator
+
+  @Test
+  fun `valid object`() {
+    assertThat(validator.validate(validObject.copy())).isEmpty()
+  }
+
+  @Test
+  fun `valid object with pre and post`() {
+    assertThat(validator.validate(validObjectAllFields.copy())).isEmpty()
+  }
+
+  @Test
+  fun `invalid pre, main and post locationIds`() {
+    assertThat(
+      validator.validate(
+        validObjectAllFields.copy(
+          main = validObjectAllFields.main.copy(locationId = null),
+          pre = validObjectAllFields.pre!!.copy(locationId = null),
+          post = validObjectAllFields.post!!.copy(locationId = null),
+
+        )
+      )
+    ).hasSize(3)
+  }
+
+  companion object {
+    val validObject = VideoLinkBookingSpecification(
+      bookingId = 10L,
+      court = "The Court",
+      courtId = null,
+      madeByTheCourt = false,
+      main = VideoLinkAppointmentSpecification(
+        startTime = LocalDateTime.of(2021, 1, 1, 9, 0),
+        endTime = LocalDateTime.of(2021, 1, 1, 9, 30),
+        locationId = 1L,
+      )
+    )
+
+    val validObjectAllFields = validObject.copy(
+      courtId = "CRT",
+      pre = VideoLinkAppointmentSpecification(
+        startTime = LocalDateTime.of(2021, 1, 1, 8, 45),
+        endTime = LocalDateTime.of(2021, 1, 1, 9, 0),
+        locationId = 2L,
+      ),
+      post = VideoLinkAppointmentSpecification(
+        startTime = LocalDateTime.of(2021, 1, 1, 9, 30),
+        endTime = LocalDateTime.of(2021, 1, 1, 9, 45),
+        locationId = 3L,
+      )
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/dto/VideoLinkBookingUpdateSpecificationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/dto/VideoLinkBookingUpdateSpecificationTest.kt
@@ -1,0 +1,64 @@
+package uk.gov.justice.digital.hmpps.whereabouts.dto
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import javax.validation.Validation
+import javax.validation.Validator
+
+class VideoLinkBookingUpdateSpecificationTest {
+  private val validator: Validator = Validation.buildDefaultValidatorFactory().validator
+
+  @Test
+  fun `valid object`() {
+    Assertions.assertThat(validator.validate(validObject.copy())).isEmpty()
+  }
+
+  @Test
+  fun `invalid pre, main and post locationIds`() {
+    Assertions.assertThat(
+      validator.validate(
+        validObject.copy(
+          pre = validObject.pre!!.copy(locationId = null),
+          main = validObject.main.copy(locationId = null),
+          post = validObject.post!!.copy(locationId = null)
+        )
+      )
+    ).hasSize(3)
+  }
+
+  @Test
+  fun `absent pre and post is valid`() {
+    Assertions.assertThat(
+      validator.validate(validObject.copy(pre = null, post = null))
+    ).isEmpty()
+  }
+
+  @Test
+  fun `zero length courtId is invalid`() {
+    Assertions.assertThat(
+      validator.validate(validObject.copy(courtId = ""))
+    ).hasSize(1)
+  }
+
+  companion object {
+    val validObject = VideoLinkBookingUpdateSpecification(
+      courtId = "CRT",
+      pre = VideoLinkAppointmentSpecification(
+        startTime = LocalDateTime.of(2021, 1, 1, 8, 45),
+        endTime = LocalDateTime.of(2021, 1, 1, 9, 0),
+        locationId = 1L,
+      ),
+      main = VideoLinkAppointmentSpecification(
+        startTime = LocalDateTime.of(2021, 1, 1, 9, 0),
+        endTime = LocalDateTime.of(2021, 1, 1, 9, 30),
+        locationId = 2L,
+      ),
+      post = VideoLinkAppointmentSpecification(
+        startTime = LocalDateTime.of(2021, 1, 1, 9, 30),
+        endTime = LocalDateTime.of(2021, 1, 1, 9, 45),
+        locationId = 3L,
+      )
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/integration/CourtIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/integration/CourtIntegrationTest.kt
@@ -27,7 +27,7 @@ class CourtIntegrationTest(
   @MockBean
   lateinit var telemetryClient: TelemetryClient
 
-  val tomorrow: LocalDateTime = LocalDateTime.now().truncatedTo(ChronoUnit.DAYS).plusDays(1)
+  private val tomorrow: LocalDateTime = LocalDateTime.now().truncatedTo(ChronoUnit.DAYS).plusDays(1)
   val yesterday: LocalDateTime = LocalDateTime.now().truncatedTo(ChronoUnit.DAYS).minusDays(1)
   val referenceTime: LocalDateTime = tomorrow.plusHours(9)
 
@@ -443,6 +443,7 @@ class CourtIntegrationTest(
               {
                 "comment": "New comment",
                 "madeByTheCourt": false,
+                "courtId": "CRT",
                 "main": {
                   "locationId": 2,
                   "startTime": "${referenceTime.format(ISO_LOCAL_DATE_TIME)}",
@@ -466,6 +467,7 @@ class CourtIntegrationTest(
               {
                 "comment": "New comment",
                 "madeByTheCourt": false,
+                "courtId": "CRT",
                 "main": {
                   "locationId" : 2,
                   "startTime" : "${referenceTime.format(ISO_LOCAL_DATE_TIME)}",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/court/VideoLinkBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/court/VideoLinkBookingServiceTest.kt
@@ -684,56 +684,6 @@ class VideoLinkBookingServiceTest {
           }
         )
     }
-
-    @Test
-    fun `If courtId is null - update main`() {
-      val service = service()
-
-      val theBooking = VideoLinkBooking(
-        id = 1L,
-        offenderBookingId = 30L,
-        courtName = "The court",
-        madeByTheCourt = true
-      )
-      theBooking.addMainAppointment(appointmentId = 40L, id = 2L)
-
-      whenever(videoLinkBookingRepository.findById(anyLong())).thenReturn(Optional.of(theBooking))
-      whenever(prisonApiServiceAuditable.postAppointment(anyLong(), any())).thenReturn(Event(3L, "WRI"))
-
-      val updateSpecification = VideoLinkBookingUpdateSpecification(
-        courtId = null,
-        comment = "New Comment",
-        main = VideoLinkAppointmentSpecification(
-          locationId = 99L,
-          startTime = referenceTime,
-          endTime = referenceTime.plusMinutes(30),
-        )
-      )
-
-      service.updateVideoLinkBooking(1L, updateSpecification)
-
-      verify(prisonApiService).deleteAppointment(40L)
-      verify(prisonApiServiceAuditable).postAppointment(
-        30L,
-        CreateBookingAppointment(
-          appointmentType = "VLB",
-          locationId = 99L,
-          startTime = "2020-10-09T10:30",
-          endTime = "2020-10-09T11:00",
-          comment = "New Comment"
-        )
-      )
-
-      val expectedAfterUpdate =
-        VideoLinkBooking(id = 1L, offenderBookingId = 30L, courtName = "The court", courtId = null, madeByTheCourt = true)
-      expectedAfterUpdate.addMainAppointment(3L)
-
-      assertThat(theBooking)
-        .usingRecursiveComparison()
-        .isEqualTo(expectedAfterUpdate)
-
-      verify(videoLinkBookingEventListener).bookingUpdated(expectedAfterUpdate, updateSpecification)
-    }
   }
 
   @Nested


### PR DESCRIPTION
- Make `courtId` mandatory in `VideoLinkBookingUpdateSpecification`
- 2 line change to `VideoLinkBookingService` at line 90 to remove redundant null check.
- Add missing `@field:` prefix to `@Valid` annotations in `VideoLinkBookingSpecification` and `VideoLinkBookingUpdateSpecification` and add some tests to show that they work.