### PR TITLE
SDI-213: ✨ New endpoint for prisoners unaccounted for

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/controllers/AttendancesController.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/controllers/AttendancesController.kt
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.whereabouts.dto.ScheduledResponse
 import uk.gov.justice.digital.hmpps.whereabouts.dto.attendance.AbsencesResponse
 import uk.gov.justice.digital.hmpps.whereabouts.dto.attendance.AttendanceChangesResponse
 import uk.gov.justice.digital.hmpps.whereabouts.dto.attendance.AttendanceHistoryDto
@@ -180,6 +181,17 @@ class AttendancesController(private val attendanceService: AttendanceService) {
   ): AttendancesResponse = AttendancesResponse(
     attendances = attendanceService.getAttendanceForOffendersThatHaveScheduledActivity(prisonId, date, period)
   )
+
+  @GetMapping("/{prison}/unaccounted-for")
+  @Operation(
+    description = "Return a set of prisoners that haven't attended a scheduled activity",
+    summary = "Request unaccounted for prisoners"
+  )
+  fun getPrisonersUnaccountedFor(
+    @Parameter(name = "Prison id (LEI)") @PathVariable(name = "prison") prisonId: String,
+    @Parameter(name = "Date of event in format YYYY-MM-DD", required = true) @RequestParam(name = "date") @DateTimeFormat(iso = DATE) date: LocalDate,
+    @Parameter(name = "Time period", required = true) @RequestParam(name = "period") period: TimePeriod,
+  ) = ScheduledResponse(attendanceService.getPrisonersUnaccountedFor(prisonId, date, period))
 
   @GetMapping("/{prison}/absences-for-scheduled-activities/{absentReason}")
   @Operation(

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/dto/PrisonerScheduleDto.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/dto/PrisonerScheduleDto.kt
@@ -1,0 +1,100 @@
+package uk.gov.justice.digital.hmpps.whereabouts.dto
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import io.swagger.annotations.ApiModel
+import io.swagger.annotations.ApiModelProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.whereabouts.model.TimePeriod
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotNull
+import javax.validation.constraints.Size
+
+@ApiModel(description = "Scheduled response")
+data class ScheduledResponse(
+  @ApiModelProperty(value = "List of scheduled events")
+  val scheduled: List<PrisonerScheduleDto>
+)
+
+@Schema(description = "Prisoner Schedule")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class PrisonerScheduleDto(
+  @Schema(required = true, description = "Offender number (e.g. NOMS Number)")
+  val offenderNo: String,
+
+  @Schema(description = "Activity id if any. Used to attend or pay the event")
+  val eventId: Long?,
+
+  @Schema(description = "Booking id for offender")
+  val bookingId: Long?,
+
+  @Schema(
+    required = true,
+    description = "The number which (uniquely) identifies the internal location associated with the Scheduled Event (Prisoner Schedule)"
+  )
+  val locationId: @NotNull Long?,
+
+  @Schema(required = true, description = "Offender first name")
+  val firstName: @NotBlank String?,
+
+  @Schema(required = true, description = "Offender last name")
+  val lastName: @NotBlank String?,
+
+  @Schema(required = true, description = "Offender cell")
+  val cellLocation: @NotBlank String?,
+
+  @Schema(required = true, description = "Event code")
+  val event: @NotBlank String?,
+
+  @Schema(required = true, description = "Event type, e.g. VISIT, APP, PRISON_ACT")
+  val eventType: @NotBlank String?,
+
+  @Schema(required = true, description = "Description of event code")
+  val eventDescription: @NotBlank String?,
+
+  @Schema(required = true, description = "Location of the event")
+  val eventLocation: String?,
+
+  @Schema(description = "Id of an internal event location")
+  val eventLocationId: Long?,
+
+  @Schema(required = true, description = "The event's status. Includes 'CANC', meaning cancelled for 'VISIT'")
+  val eventStatus: @NotBlank String?,
+
+  @Schema(required = true, description = "Comment")
+  val comment: @Size(max = 4000) String?,
+
+  @Schema(required = true, description = "Date and time at which event starts")
+  val startTime: @NotNull LocalDateTime?,
+
+  @Schema(description = "Date and time at which event ends")
+  val endTime: LocalDateTime?,
+
+  @Schema(description = "Attendance, possible values are the codes in the 'PS_PA_OC' reference domain")
+  val eventOutcome: String?,
+
+  @Schema(description = "Possible values are the codes in the 'PERFORMANCE' reference domain")
+  val performance: String?,
+
+  @Schema(description = "No-pay reason")
+  val outcomeComment: String?,
+
+  @Schema(description = "Activity paid flag")
+  val paid: Boolean?,
+
+  @Schema(description = "Amount paid per activity session in pounds")
+  val payRate: BigDecimal?,
+
+  @Schema(description = "Activity excluded flag")
+  val excluded: Boolean?,
+
+  @Schema(description = "Activity time slot")
+  val timeSlot: TimePeriod?,
+
+  @Schema(description = "The code for the activity location")
+  val locationCode: String?,
+
+  @Schema(description = "Event scheduled has been suspended")
+  val suspended: Boolean?,
+)

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/PrisonApi.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/PrisonApi.java
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.whereabouts.dto.Event;
 import uk.gov.justice.digital.hmpps.whereabouts.dto.EventOutcomesDto;
 import uk.gov.justice.digital.hmpps.whereabouts.dto.OffenderBooking;
 import uk.gov.justice.digital.hmpps.whereabouts.dto.OffenderDetails;
+import uk.gov.justice.digital.hmpps.whereabouts.dto.PrisonerScheduleDto;
 import uk.gov.justice.digital.hmpps.whereabouts.dto.ScheduledEventDto;
 import uk.gov.justice.digital.hmpps.whereabouts.dto.prisonapi.LocationDto;
 import uk.gov.justice.digital.hmpps.whereabouts.dto.prisonapi.OffenderAttendance;
@@ -120,7 +121,17 @@ public abstract class PrisonApi {
                 .stream()
                 .map(entry -> Long.parseLong(entry.get("bookingId").toString()))
                 .collect(Collectors.toSet());
+    }
 
+    public List<PrisonerScheduleDto> getScheduledActivities(final String prisonId, final LocalDate date, final TimePeriod period) {
+        final var responseType = new ParameterizedTypeReference<List<PrisonerScheduleDto>>() {
+        };
+
+        return Objects.requireNonNull(webClient.get()
+                        .uri("/schedules/{prisonId}/activities?date={date}&timeSlot={period}", prisonId, date, period)
+                        .retrieve()
+                        .bodyToMono(responseType)
+                        .block());
     }
 
     public String getOffenderNoFromBookingId(final Long bookingId) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/integration/wiremock/PrisonApiMockServer.kt
@@ -84,8 +84,8 @@ class PrisonApiMockServer : WireMockServer(8999) {
             .withBody(
               gson.toJson(
                 listOf(
-                  mapOf("bookingId" to 1L),
-                  mapOf("bookingId" to 2L)
+                  mapOf("bookingId" to 1L, "eventId" to 2L, "offenderNo" to "A123B"),
+                  mapOf("bookingId" to 2L, "eventId" to 3L, "offenderNo" to "B123C")
                 )
               )
             )


### PR DESCRIPTION
At present DPS fires off two calls - one to Prison API to get the scheduled activities and another to Whereabouts to get the attendances.  Whereabouts then calls Prison API to get the scheduled activities in order to return the offender details for the attendances.  This means that the same Prison API endpoint is called by both.  DPS then takes the difference between both lists to find out the prisoners that are unaccounted for - those that haven't attended.

This change then adds a new endpoint to return the list of prisoners that are unaccounted for, by doing the difference in Whereabouts instead.  It calls the same endpoint in Prison API.