### PR TITLE
DCS-1888 Prevent event generation when BVL makes requests

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/AppointmentService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/AppointmentService.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkAppointment
 import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkBooking
 import uk.gov.justice.digital.hmpps.whereabouts.repository.RecurringAppointmentRepository
 import uk.gov.justice.digital.hmpps.whereabouts.repository.VideoLinkBookingRepository
+import uk.gov.justice.digital.hmpps.whereabouts.services.PrisonApi.EventPropagation
 import uk.gov.justice.digital.hmpps.whereabouts.services.court.CourtService
 import uk.gov.justice.digital.hmpps.whereabouts.services.court.VideoLinkBookingService
 import java.time.LocalDate
@@ -153,11 +154,11 @@ class AppointmentService(
       ).orElse(null)
 
     if (recurringAppointment == null) {
-      prisonApiService.deleteAppointment(appointmentId)
+      prisonApiService.deleteAppointment(appointmentId, EventPropagation.ALLOW)
       return
     }
 
-    prisonApiService.deleteAppointment(appointmentId)
+    prisonApiService.deleteAppointment(appointmentId, EventPropagation.ALLOW)
     removeSingleAppointmentInRecurringList(appointmentId, recurringAppointment)
     return
   }
@@ -170,7 +171,7 @@ class AppointmentService(
     recurringAppointment.relatedAppointments?.let {
       val appointmentIds = it.map { appointment -> appointment.id }
 
-      prisonApiService.deleteAppointments(appointmentIds)
+      prisonApiService.deleteAppointments(appointmentIds, EventPropagation.ALLOW)
 
       recurringAppointmentRepository.deleteById(recurringAppointmentId)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/AppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/AppointmentServiceTest.kt
@@ -33,6 +33,7 @@ import uk.gov.justice.digital.hmpps.whereabouts.model.TimePeriod
 import uk.gov.justice.digital.hmpps.whereabouts.repository.CourtRepository
 import uk.gov.justice.digital.hmpps.whereabouts.repository.RecurringAppointmentRepository
 import uk.gov.justice.digital.hmpps.whereabouts.repository.VideoLinkBookingRepository
+import uk.gov.justice.digital.hmpps.whereabouts.services.PrisonApi.EventPropagation
 import uk.gov.justice.digital.hmpps.whereabouts.services.court.CourtService
 import uk.gov.justice.digital.hmpps.whereabouts.services.court.VideoLinkBookingService
 import uk.gov.justice.digital.hmpps.whereabouts.utils.DataHelpers
@@ -77,66 +78,48 @@ class AppointmentServiceTest {
       val otherOffenderNo = "B2345BB"
       val otherOffenderLocation = "MDI-2-1"
 
-      whenever(prisonApiService.getScheduledAppointments(anyString(), any(), anyOrNull(), anyOrNull()))
-        .thenReturn(
-          listOf(
-            ScheduledAppointmentSearchDto(
-              id = 1L,
-              agencyId = AGENCY_ID,
-              locationId = 11L,
-              locationDescription = "A location",
-              appointmentTypeCode = "VLB",
-              appointmentTypeDescription = "Video Link Booking",
-              startTime = LocalDateTime.of(2020, 1, 1, 12, 0, 0),
-              endTime = LocalDateTime.of(2020, 1, 1, 13, 0, 0),
-              offenderNo = filteredOffenderNo,
-              firstName = "BILL",
-              lastName = "BENN",
-              createUserId = "ASMITH"
-            ),
-            ScheduledAppointmentSearchDto(
-              id = 2L,
-              agencyId = AGENCY_ID,
-              locationId = 12L,
-              locationDescription = "Another location",
-              appointmentTypeCode = "VLB",
-              appointmentTypeDescription = "Video Link Booking",
-              startTime = LocalDateTime.of(2020, 1, 2, 12, 0, 0),
-              endTime = LocalDateTime.of(2020, 1, 2, 13, 0, 0),
-              offenderNo = otherOffenderNo,
-              firstName = "ANY",
-              lastName = "NAME",
-              createUserId = "BSMITH"
-            )
+      whenever(prisonApiService.getScheduledAppointments(anyString(), any(), anyOrNull(), anyOrNull())).thenReturn(
+        listOf(
+          ScheduledAppointmentSearchDto(
+            id = 1L,
+            agencyId = AGENCY_ID,
+            locationId = 11L,
+            locationDescription = "A location",
+            appointmentTypeCode = "VLB",
+            appointmentTypeDescription = "Video Link Booking",
+            startTime = LocalDateTime.of(2020, 1, 1, 12, 0, 0),
+            endTime = LocalDateTime.of(2020, 1, 1, 13, 0, 0),
+            offenderNo = filteredOffenderNo,
+            firstName = "BILL",
+            lastName = "BENN",
+            createUserId = "ASMITH"
+          ),
+          ScheduledAppointmentSearchDto(
+            id = 2L,
+            agencyId = AGENCY_ID,
+            locationId = 12L,
+            locationDescription = "Another location",
+            appointmentTypeCode = "VLB",
+            appointmentTypeDescription = "Video Link Booking",
+            startTime = LocalDateTime.of(2020, 1, 2, 12, 0, 0),
+            endTime = LocalDateTime.of(2020, 1, 2, 13, 0, 0),
+            offenderNo = otherOffenderNo,
+            firstName = "ANY",
+            lastName = "NAME",
+            createUserId = "BSMITH"
           )
         )
-      whenever(prisonApiService.getOffenderDetailsFromOffenderNos(any()))
-        .thenReturn(
-          listOf(
-            OffenderBooking(
-              22L,
-              "123",
-              filteredOffenderNo,
-              "A",
-              "Name",
-              "MDI",
-              LocalDate.of(2000, 1, 2),
-              44L,
-              filteredOffenderLocation
-            ),
-            OffenderBooking(
-              33L,
-              "234",
-              otherOffenderNo,
-              "Another",
-              "Name",
-              "MDI",
-              LocalDate.of(2000, 1, 3),
-              55L,
-              otherOffenderLocation
-            )
+      )
+      whenever(prisonApiService.getOffenderDetailsFromOffenderNos(any())).thenReturn(
+        listOf(
+          OffenderBooking(
+            22L, "123", filteredOffenderNo, "A", "Name", "MDI", LocalDate.of(2000, 1, 2), 44L, filteredOffenderLocation
+          ),
+          OffenderBooking(
+            33L, "234", otherOffenderNo, "Another", "Name", "MDI", LocalDate.of(2000, 1, 3), 55L, otherOffenderLocation
           )
         )
+      )
 
       val filteredAppointments =
         appointmentService.getAppointments(AGENCY_ID, DATE, TIME_SLOT, OFFENDER_LOCATION_PREFIX, LOCATION_ID)
@@ -175,25 +158,24 @@ class AppointmentServiceTest {
       val exampleLastName = "BENN"
       val exampleCreateUserId = "ASMITH"
 
-      whenever(prisonApiService.getScheduledAppointments(anyString(), any(), anyOrNull(), anyOrNull()))
-        .thenReturn(
-          listOf(
-            ScheduledAppointmentSearchDto(
-              id = exampleId,
-              agencyId = AGENCY_ID,
-              locationId = exampleLocationId,
-              locationDescription = exampleLocationDescription,
-              appointmentTypeCode = exampleAppointmentType,
-              appointmentTypeDescription = exampleAppointmentTypeDescription,
-              startTime = exampleStartTime,
-              endTime = exampleEndTime,
-              offenderNo = exampleOffenderNo,
-              firstName = exampleFirstName,
-              lastName = exampleLastName,
-              createUserId = exampleCreateUserId
-            )
+      whenever(prisonApiService.getScheduledAppointments(anyString(), any(), anyOrNull(), anyOrNull())).thenReturn(
+        listOf(
+          ScheduledAppointmentSearchDto(
+            id = exampleId,
+            agencyId = AGENCY_ID,
+            locationId = exampleLocationId,
+            locationDescription = exampleLocationDescription,
+            appointmentTypeCode = exampleAppointmentType,
+            appointmentTypeDescription = exampleAppointmentTypeDescription,
+            startTime = exampleStartTime,
+            endTime = exampleEndTime,
+            offenderNo = exampleOffenderNo,
+            firstName = exampleFirstName,
+            lastName = exampleLastName,
+            createUserId = exampleCreateUserId
           )
         )
+      )
 
       val filteredAppointments = appointmentService.getAppointments(AGENCY_ID, DATE, null, null, null)
 
@@ -219,13 +201,13 @@ class AppointmentServiceTest {
 
     @Test
     fun `when getting appointments it calls prison api to get the list of appointments`() {
-      whenever(prisonApiService.getScheduledAppointments(anyString(), any(), anyOrNull(), anyOrNull()))
-        .thenReturn(emptyList())
+      whenever(prisonApiService.getScheduledAppointments(anyString(), any(), anyOrNull(), anyOrNull())).thenReturn(
+        emptyList()
+      )
 
       appointmentService.getAppointments(AGENCY_ID, DATE, TIME_SLOT, null, LOCATION_ID)
 
-      verify(prisonApiService)
-        .getScheduledAppointments(eq(AGENCY_ID), eq(DATE), eq(TIME_SLOT), eq(LOCATION_ID))
+      verify(prisonApiService).getScheduledAppointments(eq(AGENCY_ID), eq(DATE), eq(TIME_SLOT), eq(LOCATION_ID))
     }
 
     @Test
@@ -233,50 +215,48 @@ class AppointmentServiceTest {
       val offenderLocationPrefix = "WWI-1"
       val offenderNo1 = "A1234AA"
       val offenderNo2 = "B2345BB"
-      whenever(prisonApiService.getScheduledAppointments(anyString(), any(), anyOrNull(), anyOrNull()))
-        .thenReturn(
-          listOf(
-            ScheduledAppointmentSearchDto(
-              id = 1L,
-              agencyId = AGENCY_ID,
-              locationId = LOCATION_ID,
-              locationDescription = "A location",
-              appointmentTypeCode = "VLB",
-              appointmentTypeDescription = "Video Link Booking",
-              startTime = LocalDateTime.of(2020, 1, 1, 12, 0, 0),
-              endTime = LocalDateTime.of(2020, 1, 1, 13, 0, 0),
-              offenderNo = offenderNo1,
-              firstName = "BILL",
-              lastName = "BENN",
-              createUserId = "ASMITH"
-            ),
-            ScheduledAppointmentSearchDto(
-              id = 1L,
-              agencyId = AGENCY_ID,
-              locationId = LOCATION_ID,
-              locationDescription = "Another location",
-              appointmentTypeCode = "VLB",
-              appointmentTypeDescription = "Video Link Booking Again",
-              startTime = LocalDateTime.of(2020, 1, 1, 12, 0, 0),
-              endTime = LocalDateTime.of(2020, 1, 1, 13, 0, 0),
-              offenderNo = offenderNo2,
-              firstName = "BOB",
-              lastName = "BABB",
-              createUserId = "BSMITH"
-            )
+      whenever(prisonApiService.getScheduledAppointments(anyString(), any(), anyOrNull(), anyOrNull())).thenReturn(
+        listOf(
+          ScheduledAppointmentSearchDto(
+            id = 1L,
+            agencyId = AGENCY_ID,
+            locationId = LOCATION_ID,
+            locationDescription = "A location",
+            appointmentTypeCode = "VLB",
+            appointmentTypeDescription = "Video Link Booking",
+            startTime = LocalDateTime.of(2020, 1, 1, 12, 0, 0),
+            endTime = LocalDateTime.of(2020, 1, 1, 13, 0, 0),
+            offenderNo = offenderNo1,
+            firstName = "BILL",
+            lastName = "BENN",
+            createUserId = "ASMITH"
+          ),
+          ScheduledAppointmentSearchDto(
+            id = 1L,
+            agencyId = AGENCY_ID,
+            locationId = LOCATION_ID,
+            locationDescription = "Another location",
+            appointmentTypeCode = "VLB",
+            appointmentTypeDescription = "Video Link Booking Again",
+            startTime = LocalDateTime.of(2020, 1, 1, 12, 0, 0),
+            endTime = LocalDateTime.of(2020, 1, 1, 13, 0, 0),
+            offenderNo = offenderNo2,
+            firstName = "BOB",
+            lastName = "BABB",
+            createUserId = "BSMITH"
           )
         )
+      )
 
       appointmentService.getAppointments(AGENCY_ID, DATE, TIME_SLOT, offenderLocationPrefix, LOCATION_ID)
 
-      verify(prisonApiService)
-        .getOffenderDetailsFromOffenderNos(
-          eq(
-            setOf(
-              offenderNo1, offenderNo2
-            )
+      verify(prisonApiService).getOffenderDetailsFromOffenderNos(
+        eq(
+          setOf(
+            offenderNo1, offenderNo2
           )
         )
+      )
     }
   }
 
@@ -332,37 +312,18 @@ class AppointmentServiceTest {
     fun `transform into appointment details`() {
       val appointmentDetails = appointmentService.getAppointment(1)
 
-      assertThat(appointmentDetails.appointment)
-        .extracting(
-          "id",
-          "agencyId",
-          "locationId",
-          "appointmentTypeCode",
-          "offenderNo",
-          "startTime",
-          "endTime",
-          "comment"
-        )
-        .contains(
-          1L,
-          AGENCY_ID,
-          EVENT_LOCATION_ID,
-          "INTERV",
-          OFFENDER_NO,
-          START_TIME,
-          END_TIME,
-          "test"
-        )
+      assertThat(appointmentDetails.appointment).extracting(
+        "id", "agencyId", "locationId", "appointmentTypeCode", "offenderNo", "startTime", "endTime", "comment"
+      ).contains(
+        1L, AGENCY_ID, EVENT_LOCATION_ID, "INTERV", OFFENDER_NO, START_TIME, END_TIME, "test"
+      )
     }
 
     @Test
     fun `transform into video link booking`() {
       whenever(
         videoLinkBookingRepository.findByAppointmentIdsAndHearingType(
-          any(),
-          eq(HearingType.MAIN),
-          isNull(),
-          isNull()
+          any(), eq(HearingType.MAIN), isNull(), isNull()
         )
       ).thenReturn(
         listOf(DataHelpers.makeVideoLinkBooking(1L, offenderBookingId = BOOKING_ID))
@@ -370,32 +331,23 @@ class AppointmentServiceTest {
 
       val appointmentDetails = appointmentService.getAppointment(1)
 
-      assertThat(appointmentDetails.appointment)
-        .extracting(
-          "id",
-          "agencyId",
-          "locationId",
-          "appointmentTypeCode",
-          "offenderNo",
-          "startTime",
-          "endTime",
-          "createUserId"
-        )
-        .contains(1L, AGENCY_ID, EVENT_LOCATION_ID, "INTERV", OFFENDER_NO, START_TIME, END_TIME, "SA")
+      assertThat(appointmentDetails.appointment).extracting(
+        "id", "agencyId", "locationId", "appointmentTypeCode", "offenderNo", "startTime", "endTime", "createUserId"
+      ).contains(1L, AGENCY_ID, EVENT_LOCATION_ID, "INTERV", OFFENDER_NO, START_TIME, END_TIME, "SA")
 
       assertThat(appointmentDetails.videoLinkBooking?.id).isEqualTo(1L)
 
-      assertThat(appointmentDetails.videoLinkBooking?.main)
-        .extracting("id", "bookingId", "appointmentId", "court", "hearingType", "createdByUsername", "madeByTheCourt")
-        .contains(1L, BOOKING_ID, 1L, "Court name", HearingType.MAIN, "SA", true)
+      assertThat(appointmentDetails.videoLinkBooking?.main).extracting(
+        "id", "bookingId", "appointmentId", "court", "hearingType", "createdByUsername", "madeByTheCourt"
+      ).contains(1L, BOOKING_ID, 1L, "Court name", HearingType.MAIN, "SA", true)
 
-      assertThat(appointmentDetails.videoLinkBooking?.pre)
-        .extracting("id", "bookingId", "appointmentId", "court", "hearingType", "createdByUsername", "madeByTheCourt")
-        .contains(2L, BOOKING_ID, 2L, "Court name", HearingType.PRE, "SA", true)
+      assertThat(appointmentDetails.videoLinkBooking?.pre).extracting(
+        "id", "bookingId", "appointmentId", "court", "hearingType", "createdByUsername", "madeByTheCourt"
+      ).contains(2L, BOOKING_ID, 2L, "Court name", HearingType.PRE, "SA", true)
 
-      assertThat(appointmentDetails.videoLinkBooking?.post)
-        .extracting("id", "bookingId", "appointmentId", "court", "hearingType", "createdByUsername", "madeByTheCourt")
-        .contains(3L, BOOKING_ID, 3L, "Court name", HearingType.POST, "SA", true)
+      assertThat(appointmentDetails.videoLinkBooking?.post).extracting(
+        "id", "bookingId", "appointmentId", "court", "hearingType", "createdByUsername", "madeByTheCourt"
+      ).contains(3L, BOOKING_ID, 3L, "Court name", HearingType.POST, "SA", true)
     }
 
     @Test
@@ -403,18 +355,14 @@ class AppointmentServiceTest {
       whenever(recurringAppointmentRepository.findRecurringAppointmentByRelatedAppointmentsContains(any())).thenReturn(
         Optional.of(
           RecurringAppointment(
-            id = 1,
-            repeatPeriod = RepeatPeriod.FORTNIGHTLY,
-            count = 1,
-            startTime = START_TIME
+            id = 1, repeatPeriod = RepeatPeriod.FORTNIGHTLY, count = 1, startTime = START_TIME
           )
         )
       )
 
       val appointmentDetails = appointmentService.getAppointment(1)
 
-      assertThat(appointmentDetails.recurring)
-        .extracting("id", "repeatPeriod", "count", "startTime")
+      assertThat(appointmentDetails.recurring).extracting("id", "repeatPeriod", "count", "startTime")
         .contains(1L, RepeatPeriod.FORTNIGHTLY, 1L, START_TIME)
     }
 
@@ -424,39 +372,33 @@ class AppointmentServiceTest {
 
       whenever(prisonApiService.getOffenderNoFromBookingId(any())).thenReturn(OFFENDER_NO)
 
-      whenever(prisonApiService.getPrisonAppointment(4L))
-        .thenReturn(
-          DataHelpers.makePrisonAppointment(
-            eventId = 4L,
-            startTime = LocalDateTime.parse("2020-10-12T20:00"),
-            endTime = LocalDateTime.parse("2020-10-12T21:00")
-          )
+      whenever(prisonApiService.getPrisonAppointment(4L)).thenReturn(
+        DataHelpers.makePrisonAppointment(
+          eventId = 4L,
+          startTime = LocalDateTime.parse("2020-10-12T20:00"),
+          endTime = LocalDateTime.parse("2020-10-12T21:00")
         )
+      )
 
-      whenever(prisonApiService.getPrisonAppointment(2L))
-        .thenReturn(
-          DataHelpers.makePrisonAppointment(
-            eventId = 2L,
-            startTime = LocalDateTime.parse("2020-10-13T20:00"),
-            endTime = LocalDateTime.parse("2020-10-13T21:00")
-          )
+      whenever(prisonApiService.getPrisonAppointment(2L)).thenReturn(
+        DataHelpers.makePrisonAppointment(
+          eventId = 2L,
+          startTime = LocalDateTime.parse("2020-10-13T20:00"),
+          endTime = LocalDateTime.parse("2020-10-13T21:00")
         )
+      )
 
-      whenever(prisonApiService.getPrisonAppointment(3L))
-        .thenReturn(
-          DataHelpers.makePrisonAppointment(
-            eventId = 3L,
-            startTime = LocalDateTime.parse("2020-10-14T20:00"),
-            endTime = LocalDateTime.parse("2020-10-14T21:00")
-          )
+      whenever(prisonApiService.getPrisonAppointment(3L)).thenReturn(
+        DataHelpers.makePrisonAppointment(
+          eventId = 3L,
+          startTime = LocalDateTime.parse("2020-10-14T20:00"),
+          endTime = LocalDateTime.parse("2020-10-14T21:00")
         )
+      )
 
       whenever(
         videoLinkBookingRepository.findByAppointmentIdsAndHearingType(
-          any(),
-          eq(HearingType.MAIN),
-          isNull(),
-          isNull()
+          any(), eq(HearingType.MAIN), isNull(), isNull()
         )
       ).thenReturn(
         listOf(DataHelpers.makeVideoLinkBooking(4L))
@@ -484,41 +426,35 @@ class AppointmentServiceTest {
 
     @BeforeEach
     fun beforeEach() {
-      val createAppointmentDetails =
-        CreatedAppointmentDetailsDto(
-          appointmentEventId = 0,
-          bookingId = 1,
-          locationId = 2,
-          startTime = START_TIME,
-          endTime = END_TIME,
-          appointmentType = "INST"
+      val createAppointmentDetails = CreatedAppointmentDetailsDto(
+        appointmentEventId = 0,
+        bookingId = 1,
+        locationId = 2,
+        startTime = START_TIME,
+        endTime = END_TIME,
+        appointmentType = "INST"
+      )
+      whenever(prisonApiServiceAuditable.createAppointments(any())).thenReturn(
+        listOf(
+          createAppointmentDetails.copy(appointmentEventId = 1),
+          createAppointmentDetails.copy(appointmentEventId = 2),
+          createAppointmentDetails.copy(appointmentEventId = 3),
+          createAppointmentDetails.copy(appointmentEventId = 4),
         )
-      whenever(prisonApiServiceAuditable.createAppointments(any()))
-        .thenReturn(
-          listOf(
-            createAppointmentDetails.copy(appointmentEventId = 1),
-            createAppointmentDetails.copy(appointmentEventId = 2),
-            createAppointmentDetails.copy(appointmentEventId = 3),
-            createAppointmentDetails.copy(appointmentEventId = 4),
-          )
-        )
+      )
     }
 
     @Test
     fun `calls prison API to create a new appointment`() {
       appointmentService.createAppointment(
         DataHelpers.makeCreateAppointmentSpecification(
-          bookingId = BOOKING_ID,
-          startTime = START_TIME,
-          endTime = END_TIME
+          bookingId = BOOKING_ID, startTime = START_TIME, endTime = END_TIME
         )
       )
 
       verify(prisonApiServiceAuditable).createAppointments(
         DataHelpers.makeCreatePrisonAppointment(
-          bookingId = BOOKING_ID,
-          startTime = START_TIME,
-          endTime = END_TIME
+          bookingId = BOOKING_ID, startTime = START_TIME, endTime = END_TIME
         )
       )
     }
@@ -527,19 +463,13 @@ class AppointmentServiceTest {
     fun `calls prison API to create a set of repeatable appointments`() {
       appointmentService.createAppointment(
         DataHelpers.makeCreateAppointmentSpecification(
-          bookingId = BOOKING_ID,
-          startTime = START_TIME,
-          endTime = END_TIME,
-          repeat = Repeat(RepeatPeriod.DAILY, 1)
+          bookingId = BOOKING_ID, startTime = START_TIME, endTime = END_TIME, repeat = Repeat(RepeatPeriod.DAILY, 1)
         )
       )
 
       verify(prisonApiServiceAuditable).createAppointments(
         DataHelpers.makeCreatePrisonAppointment(
-          bookingId = BOOKING_ID,
-          startTime = START_TIME,
-          endTime = END_TIME,
-          repeat = Repeat(RepeatPeriod.DAILY, 1)
+          bookingId = BOOKING_ID, startTime = START_TIME, endTime = END_TIME, repeat = Repeat(RepeatPeriod.DAILY, 1)
         )
       )
     }
@@ -548,23 +478,15 @@ class AppointmentServiceTest {
     fun `should save the recurring appointment data`() {
       appointmentService.createAppointment(
         DataHelpers.makeCreateAppointmentSpecification(
-          bookingId = BOOKING_ID,
-          startTime = START_TIME,
-          endTime = END_TIME,
-          repeat = Repeat(RepeatPeriod.DAILY, 4)
+          bookingId = BOOKING_ID, startTime = START_TIME, endTime = END_TIME, repeat = Repeat(RepeatPeriod.DAILY, 4)
         )
       )
 
       verify(recurringAppointmentRepository).save(
         RecurringAppointment(
-          repeatPeriod = RepeatPeriod.DAILY,
-          count = 4,
-          startTime = START_TIME,
+          repeatPeriod = RepeatPeriod.DAILY, count = 4, startTime = START_TIME,
           relatedAppointments = mutableListOf(
-            RelatedAppointment(1),
-            RelatedAppointment(2),
-            RelatedAppointment(3),
-            RelatedAppointment(4)
+            RelatedAppointment(1), RelatedAppointment(2), RelatedAppointment(3), RelatedAppointment(4)
           )
         )
       )
@@ -574,10 +496,7 @@ class AppointmentServiceTest {
     fun `should fire an event when a recurring appointment has been created`() {
       appointmentService.createAppointment(
         DataHelpers.makeCreateAppointmentSpecification(
-          bookingId = BOOKING_ID,
-          startTime = START_TIME,
-          endTime = END_TIME,
-          repeat = Repeat(RepeatPeriod.DAILY, 1)
+          bookingId = BOOKING_ID, startTime = START_TIME, endTime = END_TIME, repeat = Repeat(RepeatPeriod.DAILY, 1)
         )
       )
 
@@ -599,19 +518,13 @@ class AppointmentServiceTest {
       val created = appointmentService.createAppointment(DataHelpers.makeCreateAppointmentSpecification())
 
       assertThat(created).extracting(
-        "bookingId",
-        "locationId",
-        "startTime",
-        "endTime",
-        "appointmentType",
-        "appointmentEventId"
+        "bookingId", "locationId", "startTime", "endTime", "appointmentType", "appointmentEventId"
+      ).contains(
+        Tuple.tuple(1L, 2L, START_TIME, END_TIME, "INST", 1L),
+        Tuple.tuple(1L, 2L, START_TIME, END_TIME, "INST", 2L),
+        Tuple.tuple(1L, 2L, START_TIME, END_TIME, "INST", 3L),
+        Tuple.tuple(1L, 2L, START_TIME, END_TIME, "INST", 4L)
       )
-        .contains(
-          Tuple.tuple(1L, 2L, START_TIME, END_TIME, "INST", 1L),
-          Tuple.tuple(1L, 2L, START_TIME, END_TIME, "INST", 2L),
-          Tuple.tuple(1L, 2L, START_TIME, END_TIME, "INST", 3L),
-          Tuple.tuple(1L, 2L, START_TIME, END_TIME, "INST", 4L)
-        )
     }
   }
 
@@ -635,17 +548,14 @@ class AppointmentServiceTest {
     @Test
     fun `should delete an appointment`() {
       appointmentService.deleteAppointment(1L)
-      verify(prisonApiService).deleteAppointment(1L)
+      verify(prisonApiService).deleteAppointment(1L, EventPropagation.ALLOW)
     }
 
     @Test
     fun `should delete video link booking`() {
       whenever(
         videoLinkBookingRepository.findByAppointmentIdsAndHearingType(
-          any(),
-          eq(HearingType.MAIN),
-          isNull(),
-          isNull()
+          any(), eq(HearingType.MAIN), isNull(), isNull()
         )
       ).thenReturn(
         listOf(DataHelpers.makeVideoLinkBooking(2L))
@@ -654,7 +564,7 @@ class AppointmentServiceTest {
       appointmentService.deleteAppointment(1L)
 
       verify(videoLinkBookingService).deleteVideoLinkBooking(2L)
-      verify(prisonApiService, never()).deleteAppointment(anyLong())
+      verify(prisonApiService, never()).deleteAppointment(anyLong(), any())
       verify(recurringAppointmentRepository, never()).deleteById(anyLong())
     }
 
@@ -677,7 +587,7 @@ class AppointmentServiceTest {
 
       appointmentService.deleteAppointment(3L)
 
-      verify(prisonApiService).deleteAppointment(3L)
+      verify(prisonApiService).deleteAppointment(3L, EventPropagation.ALLOW)
       // JPA will remove the item from the DB when removed from the list as orphanRemoval = true
       assertThat(relatedAppointments).hasSize(1)
       assertThat(relatedAppointments[0].id).isEqualTo(2L)
@@ -702,7 +612,7 @@ class AppointmentServiceTest {
 
       appointmentService.deleteAppointment(3L)
 
-      verify(prisonApiService).deleteAppointment(3L)
+      verify(prisonApiService).deleteAppointment(3L, EventPropagation.ALLOW)
       verify(recurringAppointmentRepository).deleteById(100)
     }
   }
@@ -729,7 +639,7 @@ class AppointmentServiceTest {
     fun `should delete all recurring appointments`() {
       appointmentService.deleteRecurringAppointmentSequence(100)
 
-      verify(prisonApiService).deleteAppointments(listOf(2L, 3L))
+      verify(prisonApiService).deleteAppointments(listOf(2L, 3L), EventPropagation.ALLOW)
       verify(recurringAppointmentRepository).deleteById(100)
       verify(videoLinkBookingService, never()).deleteVideoLinkBooking(anyLong())
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/PrisonApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/PrisonApiServiceTest.kt
@@ -18,6 +18,8 @@ import uk.gov.justice.digital.hmpps.whereabouts.dto.prisonapi.OffenderAttendance
 import uk.gov.justice.digital.hmpps.whereabouts.dto.prisonapi.ScheduledAppointmentDto
 import uk.gov.justice.digital.hmpps.whereabouts.integration.wiremock.PrisonApiMockServer
 import uk.gov.justice.digital.hmpps.whereabouts.model.Location
+import uk.gov.justice.digital.hmpps.whereabouts.services.PrisonApi.EventPropagation.ALLOW
+import uk.gov.justice.digital.hmpps.whereabouts.services.PrisonApi.EventPropagation.DENY
 import java.time.LocalDate
 
 class PrisonApiServiceTest {
@@ -52,9 +54,10 @@ class PrisonApiServiceTest {
   fun `when successful delete`() {
     val appointmentId = 1L
     prisonApiMockServer.stubDeleteAppointment(appointmentId, 200)
-    prisonApiService.deleteAppointment(appointmentId)
+    prisonApiService.deleteAppointment(appointmentId, DENY)
     prisonApiMockServer.verify(
       deleteRequestedFor(urlEqualTo("/api/appointments/$appointmentId"))
+        .withHeader("no-event-propagation", equalTo("true"))
     )
   }
 
@@ -62,9 +65,10 @@ class PrisonApiServiceTest {
   fun `when appointment to delete is not found`() {
     val appointmentId = 1L
     prisonApiMockServer.stubDeleteAppointment(appointmentId, 404)
-    prisonApiService.deleteAppointment(appointmentId)
+    prisonApiService.deleteAppointment(appointmentId, ALLOW)
     prisonApiMockServer.verify(
       deleteRequestedFor(urlEqualTo("/api/appointments/$appointmentId"))
+        .withHeader("no-event-propagation", equalTo("false"))
     )
   }
 
@@ -73,10 +77,11 @@ class PrisonApiServiceTest {
     val appointmentId = 1L
     prisonApiMockServer.stubDeleteAppointment(appointmentId, 500)
     Assertions.assertThrows(InternalServerError::class.java) {
-      prisonApiService.deleteAppointment(appointmentId)
+      prisonApiService.deleteAppointment(appointmentId, ALLOW)
     }
     prisonApiMockServer.verify(
       deleteRequestedFor(urlEqualTo("/api/appointments/$appointmentId"))
+        .withHeader("no-event-propagation", equalTo("false"))
     )
   }
 
@@ -86,10 +91,11 @@ class PrisonApiServiceTest {
     val comment = "New comment"
 
     prisonApiMockServer.stubUpdateAppointmentComment(appointmentId)
-    prisonApiService.updateAppointmentComment(appointmentId, comment)
+    prisonApiService.updateAppointmentComment(appointmentId, comment, ALLOW)
     prisonApiMockServer.verify(
       putRequestedFor(urlEqualTo("/api/appointments/$appointmentId/comment"))
         .withRequestBody(equalTo(comment))
+        .withHeader("no-event-propagation", equalTo("false"))
     )
   }
 
@@ -99,10 +105,11 @@ class PrisonApiServiceTest {
     val comment = ""
 
     prisonApiMockServer.stubUpdateAppointmentComment(appointmentId)
-    prisonApiService.updateAppointmentComment(appointmentId, comment)
+    prisonApiService.updateAppointmentComment(appointmentId, comment, ALLOW)
     prisonApiMockServer.verify(
       putRequestedFor(urlEqualTo("/api/appointments/$appointmentId/comment"))
         .withRequestBody(absent())
+        .withHeader("no-event-propagation", equalTo("false"))
     )
   }
 
@@ -112,9 +119,10 @@ class PrisonApiServiceTest {
     val comment = null
 
     prisonApiMockServer.stubUpdateAppointmentComment(appointmentId)
-    prisonApiService.updateAppointmentComment(appointmentId, comment)
+    prisonApiService.updateAppointmentComment(appointmentId, comment, ALLOW)
     prisonApiMockServer.verify(
       putRequestedFor(urlEqualTo("/api/appointments/$appointmentId/comment"))
+        .withHeader("no-event-propagation", equalTo("false"))
         .withRequestBody(absent())
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/court/VideoLinkBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/court/VideoLinkBookingServiceTest.kt
@@ -37,6 +37,7 @@ import uk.gov.justice.digital.hmpps.whereabouts.model.eqByProps
 import uk.gov.justice.digital.hmpps.whereabouts.repository.CourtRepository
 import uk.gov.justice.digital.hmpps.whereabouts.repository.VideoLinkAppointmentRepository
 import uk.gov.justice.digital.hmpps.whereabouts.repository.VideoLinkBookingRepository
+import uk.gov.justice.digital.hmpps.whereabouts.services.PrisonApi.EventPropagation
 import uk.gov.justice.digital.hmpps.whereabouts.services.PrisonApiService
 import uk.gov.justice.digital.hmpps.whereabouts.services.PrisonApiServiceAuditable
 import uk.gov.justice.digital.hmpps.whereabouts.services.ValidationException
@@ -238,7 +239,7 @@ class VideoLinkBookingServiceTest {
         )
       )
 
-      whenever(prisonApiServiceAuditable.postAppointment(anyLong(), any())).thenReturn(
+      whenever(prisonApiServiceAuditable.postAppointment(anyLong(), any(), any())).thenReturn(
         Event(
           mainAppointmentId,
           AGENCY_WANDSWORTH,
@@ -262,7 +263,8 @@ class VideoLinkBookingServiceTest {
           comment = "Comment",
           startTime = "2020-10-09T10:30",
           endTime = "2020-10-09T11:00"
-        )
+        ),
+        EventPropagation.DENY
       )
 
       verify(videoLinkBookingRepository).save(eqByProps(makeBooking(null)))
@@ -516,7 +518,13 @@ class VideoLinkBookingServiceTest {
         endTime = "2020-10-09T11:20"
       )
 
-      whenever(prisonApiServiceAuditable.postAppointment(offenderBookingId, mainCreateAppointment)).thenReturn(
+      whenever(
+        prisonApiServiceAuditable.postAppointment(
+          offenderBookingId,
+          mainCreateAppointment,
+          EventPropagation.DENY
+        )
+      ).thenReturn(
         Event(
           mainAppointmentId,
           AGENCY_WANDSWORTH,
@@ -525,7 +533,12 @@ class VideoLinkBookingServiceTest {
           endDateTime
         )
       )
-      whenever(prisonApiServiceAuditable.postAppointment(offenderBookingId, preCreateAppointment)).thenReturn(
+      whenever(
+        prisonApiServiceAuditable.postAppointment(
+          offenderBookingId, preCreateAppointment,
+          EventPropagation.DENY
+        )
+      ).thenReturn(
         Event(
           preAppointmentId,
           AGENCY_WANDSWORTH,
@@ -534,7 +547,12 @@ class VideoLinkBookingServiceTest {
           endDateTime
         )
       )
-      whenever(prisonApiServiceAuditable.postAppointment(offenderBookingId, postCreateAppointment)).thenReturn(
+      whenever(
+        prisonApiServiceAuditable.postAppointment(
+          offenderBookingId, postCreateAppointment,
+          EventPropagation.DENY
+        )
+      ).thenReturn(
         Event(
           postAppointmentId,
           AGENCY_WANDSWORTH,
@@ -573,9 +591,18 @@ class VideoLinkBookingServiceTest {
 
       assertThat(vlbBookingId).isEqualTo(11)
 
-      verify(prisonApiServiceAuditable).postAppointment(offenderBookingId, mainCreateAppointment)
-      verify(prisonApiServiceAuditable).postAppointment(offenderBookingId, preCreateAppointment)
-      verify(prisonApiServiceAuditable).postAppointment(offenderBookingId, postCreateAppointment)
+      verify(prisonApiServiceAuditable).postAppointment(
+        offenderBookingId, mainCreateAppointment,
+        EventPropagation.DENY
+      )
+      verify(prisonApiServiceAuditable).postAppointment(
+        offenderBookingId, preCreateAppointment,
+        EventPropagation.DENY
+      )
+      verify(prisonApiServiceAuditable).postAppointment(
+        offenderBookingId, postCreateAppointment,
+        EventPropagation.DENY
+      )
 
       verify(videoLinkBookingRepository).save(eqByProps(makeBooking(null)))
     }
@@ -616,7 +643,12 @@ class VideoLinkBookingServiceTest {
       )
 
       whenever(videoLinkBookingRepository.findById(anyLong())).thenReturn(Optional.of(theBooking))
-      whenever(prisonApiServiceAuditable.postAppointment(anyLong(), any())).thenReturn(
+      whenever(
+        prisonApiServiceAuditable.postAppointment(
+          anyLong(), any(),
+          any()
+        )
+      ).thenReturn(
         Event(
           3L,
           "WRI",
@@ -638,7 +670,10 @@ class VideoLinkBookingServiceTest {
 
       service.updateVideoLinkBooking(1L, updateSpecification)
 
-      verify(prisonApiService).deleteAppointment(40L)
+      verify(prisonApiService).deleteAppointment(
+        40L,
+        EventPropagation.DENY
+      )
       verify(prisonApiServiceAuditable).postAppointment(
         30L,
         CreateBookingAppointment(
@@ -647,7 +682,8 @@ class VideoLinkBookingServiceTest {
           startTime = "2020-10-09T10:30",
           endTime = "2020-10-09T11:00",
           comment = "New Comment"
-        )
+        ),
+        EventPropagation.DENY
       )
 
       val expectedAfterUpdate =
@@ -727,7 +763,7 @@ class VideoLinkBookingServiceTest {
       )
 
       whenever(videoLinkBookingRepository.findById(anyLong())).thenReturn(Optional.of(theBooking))
-      whenever(prisonApiServiceAuditable.postAppointment(anyLong(), any())).thenReturn(
+      whenever(prisonApiServiceAuditable.postAppointment(anyLong(), any(), any())).thenReturn(
         Event(
           9999L,
           "WRI",
@@ -760,9 +796,18 @@ class VideoLinkBookingServiceTest {
         )
       )
 
-      verify(prisonApiService).deleteAppointment(40L)
-      verify(prisonApiService).deleteAppointment(41L)
-      verify(prisonApiService).deleteAppointment(42L)
+      verify(prisonApiService).deleteAppointment(
+        40L,
+        EventPropagation.DENY
+      )
+      verify(prisonApiService).deleteAppointment(
+        41L,
+        EventPropagation.DENY
+      )
+      verify(prisonApiService).deleteAppointment(
+        42L,
+        EventPropagation.DENY
+      )
 
       verify(prisonApiServiceAuditable).postAppointment(
         30L,
@@ -772,7 +817,8 @@ class VideoLinkBookingServiceTest {
           startTime = "2020-10-09T10:30",
           endTime = "2020-10-09T11:00",
           comment = "New Comment"
-        )
+        ),
+        EventPropagation.DENY
       )
 
       verify(prisonApiServiceAuditable).postAppointment(
@@ -783,7 +829,8 @@ class VideoLinkBookingServiceTest {
           startTime = "2020-10-09T11:00",
           endTime = "2020-10-09T11:30",
           comment = "New Comment"
-        )
+        ),
+        EventPropagation.DENY
       )
 
       verify(prisonApiServiceAuditable).postAppointment(
@@ -794,7 +841,8 @@ class VideoLinkBookingServiceTest {
           startTime = "2020-10-09T11:30",
           endTime = "2020-10-09T12:00",
           comment = "New Comment"
-        )
+        ),
+        EventPropagation.DENY
       )
 
       assertThat(theBooking)
@@ -880,9 +928,9 @@ class VideoLinkBookingServiceTest {
 
       service.deleteVideoLinkBooking(videoLinkBooking.id!!)
 
-      verify(prisonApiService).deleteAppointment(preAppointmentId)
-      verify(prisonApiService).deleteAppointment(mainAppointmentId)
-      verify(prisonApiService).deleteAppointment(postAppointmentId)
+      verify(prisonApiService).deleteAppointment(preAppointmentId, EventPropagation.DENY)
+      verify(prisonApiService).deleteAppointment(mainAppointmentId, EventPropagation.DENY)
+      verify(prisonApiService).deleteAppointment(postAppointmentId, EventPropagation.DENY)
 
       verify(videoLinkBookingRepository).deleteById(videoLinkBooking.id!!)
       verify(videoLinkBookingEventListener).bookingDeleted(videoLinkBooking)
@@ -1250,7 +1298,7 @@ class VideoLinkBookingServiceTest {
       whenever(videoLinkAppointmentRepository.findOneByAppointmentId(any())).thenReturn(Optional.of(booking.appointments[HearingType.MAIN]!!))
 
       service.deleteAppointments(1)
-      verify(prisonApiService, times(1)).deleteAppointments(listOf(2L, 3L))
+      verify(prisonApiService, times(1)).deleteAppointments(listOf(2L, 3L), EventPropagation.DENY)
       verify(videoLinkBookingRepository, times(1)).delete(booking)
       verify(videoLinkAppointmentRepository, times(0)).delete(any())
     }
@@ -1317,9 +1365,9 @@ class VideoLinkBookingServiceTest {
 
       service.updateVideoLinkBookingComment(1L, newComment)
 
-      verify(prisonApiService).updateAppointmentComment(10L, newComment)
-      verify(prisonApiService).updateAppointmentComment(11L, newComment)
-      verify(prisonApiService).updateAppointmentComment(12L, newComment)
+      verify(prisonApiService).updateAppointmentComment(10L, newComment, EventPropagation.DENY)
+      verify(prisonApiService).updateAppointmentComment(11L, newComment, EventPropagation.DENY)
+      verify(prisonApiService).updateAppointmentComment(12L, newComment, EventPropagation.DENY)
       verifyNoMoreInteractions(prisonApiService)
     }
 
@@ -1345,7 +1393,7 @@ class VideoLinkBookingServiceTest {
 
       service.updateVideoLinkBookingComment(1L, newComment)
 
-      verify(prisonApiService).updateAppointmentComment(11L, newComment)
+      verify(prisonApiService).updateAppointmentComment(11L, newComment, EventPropagation.DENY)
       verifyNoMoreInteractions(prisonApiService)
     }
   }


### PR DESCRIPTION
BVL consumes events regarding appointments but is also sometimes the source of the event.

When BVL is the source of an event, there is a race conditions, where the event listener processes the event before BVL has committed its transaction which produced the event.
 
This is a bit of hack maybe, that will prevent raising events for appointments that BVL is modifying.
It has the knock on effect that other systems will not be notified of these