### PR TITLE
MAP-253: Improve BVL CSV download room name lookup performance

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/LocationService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/LocationService.kt
@@ -25,7 +25,7 @@ class LocationService(
 
   fun getAllLocationsForPrison(agencyId: String): List<LocationIdAndDescription> =
     prisonApiService
-      .getAllLocationsInAgency(agencyId)
+      .getAgencyLocationsForTypeUnrestricted(agencyId, "APP")
       .map { LocationIdAndDescription(it.locationId, it.userDescription ?: it.description) }
 
   fun getLocationPrefixFromGroup(agencyId: String, group: String): LocationPrefixDto {

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/VideoLinkBookingEventService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/VideoLinkBookingEventService.kt
@@ -1,7 +1,5 @@
 package uk.gov.justice.digital.hmpps.whereabouts.services.court
 
-import kotlinx.coroutines.async
-import kotlinx.coroutines.runBlocking
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.whereabouts.model.LocationIdAndDescription
@@ -57,12 +55,10 @@ class VideoLinkBookingEventService(
     return if (agencyId == null) listOf() else locationService.getAllLocationsForPrison(agencyId)
   }
 
-  private fun roomNamesMap(agencyIds: List<String?>): Map<Long, String> = runBlocking {
-    val roomNames = agencyIds.map {
-      async { getRoomsInLocation(it) }
-    }.map { it.await() }
-
-    roomNames.flatten().associateBy({ it.locationId }, { it.description })
+  private fun roomNamesMap(agencyIds: List<String?>): Map<Long, String> {
+    return agencyIds.map(::getRoomsInLocation)
+      .flatten()
+      .associateBy({ it.locationId }, { it.description })
   }
 
   private fun withRoomNames(event: VideoLinkBookingEvent, roomNames: Map<Long, String>): VideoLinkBookingEventWithRoomNames {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/integration/VideoLinkBookingEventIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/integration/VideoLinkBookingEventIntegrationTest.kt
@@ -99,7 +99,7 @@ class VideoLinkBookingEventIntegrationTest : IntegrationTest() {
 
   @Test
   fun `With room names`() {
-    prisonApiMockServer.stubGetAllLocationsForPrison("MDI", getAllRooms())
+    prisonApiMockServer.stubGetAgencyLocationsForTypeUnrestricted("MDI", "APP", getAllRooms())
 
     val uri = "$baseUrl?start-date=${LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)}&room-names=true"
     webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/LocationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/LocationServiceTest.kt
@@ -105,7 +105,7 @@ class LocationServiceTest {
       operationalCapacity = 2, userDescription = "Video Room C", internalLocationCode = "Room 3",
     )
 
-    whenever(prisonApiService.getAllLocationsInAgency("MDI"))
+    whenever(prisonApiService.getAgencyLocationsForTypeUnrestricted("MDI", "APP"))
       .thenReturn(listOf(location1, location2, location3))
 
     assertThat(locationService.getAllLocationsForPrison("MDI"))
@@ -132,7 +132,7 @@ class LocationServiceTest {
       operationalCapacity = 2, userDescription = "Video Room B", internalLocationCode = "Room 2",
     )
 
-    whenever(prisonApiService.getAllLocationsInAgency("MDI"))
+    whenever(prisonApiService.getAgencyLocationsForTypeUnrestricted("MDI", "APP"))
       .thenReturn(listOf(location1, location2))
 
     assertThat(locationService.getAllLocationsForPrison("MDI"))


### PR DESCRIPTION
- Don't use coroutines anymore, as they don't seem to work well with Spring MVC
- Only look up certain types of location (but don't filter for only VIDE)