### PR TITLE
MAP-253: Add eventId to BVL CSV

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/VideoLinkBookingEventService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/VideoLinkBookingEventService.kt
@@ -58,6 +58,7 @@ class VideoLinkBookingEventService(
 
   private fun withRoomNames(event: VideoLinkBookingEvent, roomNames: Map<Long, String>): VideoLinkBookingEventWithRoomNames {
     return VideoLinkBookingEventWithRoomNames(
+      eventId = event.eventId,
       eventType = event.eventType,
       timestamp = event.timestamp,
       userId = event.userId,


### PR DESCRIPTION
The eventId was not being copied over properly so it was missing from the CSV.