### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -1,6 +1,3 @@
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
 generic-service:
   replicaCount: 2
 
@@ -11,15 +8,9 @@ generic-service:
     ELITE2API_ENDPOINT_URL: "https://prison-api-dev.prison.service.justice.gov.uk"
     OAUTH_ENDPOINT_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     CASENOTES_ENDPOINT_URL: "https://dev.offender-case-notes.service.justice.gov.uk"
-    SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth/.well-known/jwks.json"
+    SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI: "https://sign-in-dev.hmp\
+      ps.service.justice.gov.uk/auth/.well-known/jwks.json"
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
-    temp-devs-novpn: "82.42.245.212/32"
+    groups:
+      - internal

--- a/helm_deploy/whereabouts-api/Chart.yaml
+++ b/helm_deploy/whereabouts-api/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.2.0
 
 dependencies:
   - name: generic-service
-    version: 2.6.4
+    version: "2.7"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.2

--- a/helm_deploy/whereabouts-api/values.yaml
+++ b/helm_deploy/whereabouts-api/values.yaml
@@ -1,4 +1,3 @@
----
 # Values here are the same across all environments
 generic-service:
 
@@ -9,7 +8,7 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/whereabouts-api
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 8080
 
   ingress:
@@ -54,14 +53,8 @@ generic-service:
       HMPPS_SQS_QUEUES_WHEREABOUTS_DLQ_NAME: "sqs_wb_name"
 
   allowlist:
-      office: "217.33.148.210/32"
-      health-kick: "35.177.252.195/32"
-      mojvpn: "81.134.202.29/32"
-      cloudplatform-live1-1: "35.178.209.113/32"
-      cloudplatform-live1-2: "3.8.51.207/32"
-      cloudplatform-live1-3: "35.177.252.54/32"
-      petty-france-wifi: "213.121.161.112/28"
-      global-protect: "35.176.93.186/32"
+    groups:
+      - internal
 
 generic-prometheus-alerts:
   targetApplication: whereabouts-api


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

2 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/values-dev.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `INTERNAL`
- The size of the allowlist defined in this file will change: `9 => 0 (9 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick (35.177.252.195/32)
  

- temp-devs-novpn (82.42.245.212/32)
  

## Allowlist: helm_deploy/whereabouts-api/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `INTERNAL`
- The size of the allowlist defined in this file will change: `8 => 0 (8 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick (35.177.252.195/32)
  
