### PR TITLE
MAP-1170 change exception handler to actual exception thrown

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/VideoLinkBookingService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/VideoLinkBookingService.kt
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.whereabouts.dto.CreateBookingAppointment
 import uk.gov.justice.digital.hmpps.whereabouts.dto.Event
 import uk.gov.justice.digital.hmpps.whereabouts.dto.OffenderBooking
@@ -511,7 +512,7 @@ class VideoLinkBookingService(
         prisonId,
         DepartmentType.VIDEOLINK_CONFERENCING_CENTRE,
       )?.emailAddress
-    } catch (e: EntityNotFoundException) {
+    } catch (e: WebClientResponseException) {
       log.info(
         "Could not get prison VCC email address for {} from prisonRegister. Exception message {}",
         prisonId,
@@ -524,7 +525,7 @@ class VideoLinkBookingService(
   fun getPrisonName(prisonId: String): String? {
     try {
       return prisonRegisterClient.getPrisonDetails(prisonId)?.prisonName
-    } catch (e: EntityNotFoundException) {
+    } catch (e: WebClientResponseException) {
       log.info("Could not get prison name for {} from prisonRegister. Error message: {}", prisonId, e.message)
     }
     return null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/integration/wiremock/PrisonRegisterApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/integration/wiremock/PrisonRegisterApiMockServer.kt
@@ -1,0 +1,41 @@
+package uk.gov.justice.digital.hmpps.whereabouts.integration.wiremock
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+
+class PrisonRegisterApiMockServer : WireMockServer(8999) {
+
+  fun stubGetPrisonEmailAddress(agencyId: String) {
+    stubFor(
+      get(urlEqualTo("/secure/prisons/id/$agencyId/department/contact-details?departmentType=VIDEOLINK_CONFERENCING_CENTRE"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              """
+              {
+                "type": "VIDEOLINK_CONFERENCING_CENTRE",
+                "emailAddress": "someEmailAddress@gov.uk",
+                "phoneNumber": null,
+                "webAddress": null
+               }
+              """,
+            )
+            .withStatus(200),
+        ),
+    )
+  }
+
+  fun stubGetPrisonEmailAddressReturnsNotFound(agencyId: String) {
+    stubFor(
+      get(urlEqualTo("/secure/prisons/id/$agencyId/department/contact-details?departmentType=VIDEOLINK_CONFERENCING_CENTRE"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(404),
+        ),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/PrisonRegisterApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/PrisonRegisterApiServiceTest.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.whereabouts.services
+
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import uk.gov.justice.digital.hmpps.whereabouts.integration.wiremock.PrisonRegisterApiMockServer
+import uk.gov.justice.digital.hmpps.whereabouts.services.court.VideoLinkBookingService
+
+class PrisonRegisterApiServiceTest {
+
+  private lateinit var prisonRegisterClient: PrisonRegisterClient
+
+  companion object {
+    @JvmField
+    internal val prisonRegisterApiMockServer = PrisonRegisterApiMockServer()
+
+    @BeforeAll
+    @JvmStatic
+    fun startMocks() {
+      prisonRegisterApiMockServer.start()
+    }
+
+    @AfterAll
+    @JvmStatic
+    fun stopMocks() {
+      prisonRegisterApiMockServer.stop()
+    }
+  }
+
+  @BeforeEach
+  fun resetStubs() {
+    prisonRegisterApiMockServer.resetAll()
+    val webClient = WebClient.create("http://localhost:${prisonRegisterApiMockServer.port()}")
+    prisonRegisterClient = PrisonRegisterClient(webClient)
+  }
+
+  @Test
+  fun `happy path`() {
+    prisonRegisterApiMockServer.stubGetPrisonEmailAddress("NMI")
+    var result = prisonRegisterClient.getPrisonEmailAddress("NMI", VideoLinkBookingService.DepartmentType.VIDEOLINK_CONFERENCING_CENTRE)
+    Assertions.assertEquals(result?.emailAddress, "someEmailAddress@gov.uk")
+  }
+
+  @Test
+  fun `details not found`() {
+    prisonRegisterApiMockServer.stubGetPrisonEmailAddressReturnsNotFound("NMI")
+    Assertions.assertThrows(WebClientResponseException.NotFound::class.java) {
+      prisonRegisterClient.getPrisonEmailAddress("NMI", VideoLinkBookingService.DepartmentType.VIDEOLINK_CONFERENCING_CENTRE)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/VideoLinkBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/VideoLinkBookingServiceTest.kt
@@ -1,0 +1,90 @@
+package uk.gov.justice.digital.hmpps.whereabouts.services
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import uk.gov.justice.digital.hmpps.whereabouts.repository.VideoLinkAppointmentRepository
+import uk.gov.justice.digital.hmpps.whereabouts.repository.VideoLinkBookingRepository
+import uk.gov.justice.digital.hmpps.whereabouts.services.court.CourtService
+import uk.gov.justice.digital.hmpps.whereabouts.services.court.VideoLinkBookingEventListener
+import uk.gov.justice.digital.hmpps.whereabouts.services.court.VideoLinkBookingService
+import java.time.Clock
+
+class VideoLinkBookingServiceTest {
+
+  private val courtService: CourtService = mock()
+  private val prisonApiService: PrisonApiService = mock()
+  private val prisonApiServiceAuditable: PrisonApiServiceAuditable = mock()
+  private val videoLinkAppointmentRepository: VideoLinkAppointmentRepository = mock()
+  private val videoLinkBookingRepository: VideoLinkBookingRepository = mock()
+  private val clock: Clock = mock()
+  private val videoLinkBookingEventListener: VideoLinkBookingEventListener = mock()
+  private val notifyService: NotifyService = mock()
+  private val prisonRegisterClient: PrisonRegisterClient = mock()
+
+  private val videoLinkBookingService = VideoLinkBookingService(
+    false,
+    courtService,
+    prisonApiService,
+    prisonApiServiceAuditable,
+    videoLinkAppointmentRepository,
+    videoLinkBookingRepository,
+    clock,
+    videoLinkBookingEventListener,
+    notifyService,
+    prisonRegisterClient,
+  )
+
+  @Test
+  fun `getPrisonEmail - happy path`() {
+    whenever(
+      prisonRegisterClient.getPrisonEmailAddress(
+        "NMI",
+        VideoLinkBookingService.DepartmentType.VIDEOLINK_CONFERENCING_CENTRE,
+      ),
+    ).thenReturn(
+      PrisonRegisterClient.DepartmentDto("VIDEOLINK_CONFERENCING_CENTRE", "someEmailAddress@gov.uk"),
+    )
+
+    Assertions.assertEquals(videoLinkBookingService.getPrisonEmail("NMI"), "someEmailAddress@gov.uk")
+  }
+
+  @Test
+  fun `getPrisonEmail - should handle not found exception`() {
+    whenever(
+      prisonRegisterClient.getPrisonEmailAddress(
+        any(),
+        any(),
+      ),
+    ).thenThrow(WebClientResponseException.NotFound::class.java)
+
+    Assertions.assertEquals(videoLinkBookingService.getPrisonEmail("NMI"), null)
+  }
+
+  @Test
+  fun `getPrisonName - happy path`() {
+    whenever(
+      prisonRegisterClient.getPrisonDetails(
+        "NMI",
+      ),
+    ).thenReturn(
+      PrisonRegisterClient.PrisonDetail("NMI", "HMP Nottingham"),
+    )
+
+    Assertions.assertEquals(videoLinkBookingService.getPrisonName("NMI"), "HMP Nottingham")
+  }
+
+  @Test
+  fun `getPrisonName - should handle not found exception`() {
+    whenever(
+      prisonRegisterClient.getPrisonDetails(
+        any(),
+      ),
+    ).thenThrow(WebClientResponseException.NotFound::class.java)
+
+    Assertions.assertEquals(videoLinkBookingService.getPrisonName("NMI"), null)
+  }
+}


### PR DESCRIPTION
Exception handing was failing (as consequently preventing the sqs message from being fully actioned and this looping into DLQ) because the incorrect exception type was being tested for. 
Actual exception thrown was WebClientResponseException not EntityNotFoundException