### PR TITLE
BAVL 251 adding feature switch to allow event subscription to be turned off for old BVLS when new BVLS service is available.

### DIFF
--- a/helm_deploy/whereabouts-api/values.yaml
+++ b/helm_deploy/whereabouts-api/values.yaml
@@ -36,6 +36,7 @@ generic-service:
     APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY)"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     HMPPS_SQS_USE_WEB_TOKEN: "true"
+    FEATURE_BVLS_ENABLED: "true"
 
   namespace_secrets:
     whereabouts-api:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/listeners/SqsDomainEventListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/listeners/SqsDomainEventListenerTest.kt
@@ -2,26 +2,25 @@ package uk.gov.justice.digital.hmpps.whereabouts.listeners
 
 import com.google.gson.Gson
 import jakarta.persistence.EntityNotFoundException
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
-import uk.gov.justice.digital.hmpps.whereabouts.services.PrisonApiService
 import uk.gov.justice.digital.hmpps.whereabouts.services.court.VideoLinkBookingService
 import wiremock.org.apache.commons.io.IOUtils
 import java.nio.charset.StandardCharsets
 
 class SqsDomainEventListenerTest {
   private val videoLinkBookingService: VideoLinkBookingService = mock()
-  private val prisonApiService: PrisonApiService = mock()
+  private val bvlsEnabledListener = SqsDomainEventListener(videoLinkBookingService, Gson(), true)
 
   @Test
-  fun `should call delete appointments when event type is prison-offender-events prisoner released`() {
-    val domainListener = SqsDomainEventListener(videoLinkBookingService, Gson())
-    domainListener.handleDomainEvents(getJson("/listeners/prison-offender-events.prisoner.released.json"))
+  fun `should call delete appointments when event type is prison-offender-events prisoner released and bvls enabled`() {
+    bvlsEnabledListener.handleDomainEvents(getJson("/listeners/prison-offender-events.prisoner.released.json"))
     verify(videoLinkBookingService).deleteAppointmentWhenTransferredOrReleased(
       ReleasedOffenderEventMessage(
         occurredAt = "2023-11-20T17:07:58Z",
@@ -35,23 +34,28 @@ class SqsDomainEventListenerTest {
   }
 
   @Test
-  fun `should not call delete appointments when event type is not released`() {
-    val domainListener = SqsDomainEventListener(videoLinkBookingService, Gson())
-    domainListener.handleDomainEvents(getJson("/listeners/prison-offender-events.prisoner.unknown.json"))
+  fun `should not call delete appointments when event type is not released and bvls enabled`() {
+    bvlsEnabledListener.handleDomainEvents(getJson("/listeners/prison-offender-events.prisoner.unknown.json"))
     verify(videoLinkBookingService, never()).deleteAppointmentWhenTransferredOrReleased(any())
   }
 
   @Test
   fun `should throw exception if upstream service fails`() {
-    val domainListener = SqsDomainEventListener(videoLinkBookingService, Gson())
-
     whenever(videoLinkBookingService.deleteAppointmentWhenTransferredOrReleased(any())).thenThrow(
       EntityNotFoundException(),
     )
 
-    Assertions.assertThrows(EntityNotFoundException::class.java) {
-      domainListener.handleDomainEvents(getJson("/listeners/prison-offender-events.prisoner.released.json"))
+    assertThrows(EntityNotFoundException::class.java) {
+      bvlsEnabledListener.handleDomainEvents(getJson("/listeners/prison-offender-events.prisoner.released.json"))
     }
+  }
+
+  @Test
+  fun `should ignore events when bvls not enabled`() {
+    SqsDomainEventListener(videoLinkBookingService, Gson(), false)
+      .handleDomainEvents(getJson("/listeners/prison-offender-events.prisoner.released.json"))
+
+    verifyNoInteractions(videoLinkBookingService)
   }
 
   private fun getJson(filename: String): String {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/model/VideoLinkBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/model/VideoLinkBookingTest.kt
@@ -9,18 +9,18 @@ import uk.gov.justice.digital.hmpps.whereabouts.utils.DataHelpers
 import java.time.LocalDateTime
 
 class VideoLinkBookingTest {
-  val COURT_NAME = "The Court"
-  val COURT_ID = "TC"
-  val COURT_HEARING_TYPE = CourtHearingType.APPEAL
-  val PRISON_ID = "WWI"
-  val START_DATE_TIME = LocalDateTime.of(2022, 1, 1, 10, 0, 0)
-  val END_DATE_TIME = LocalDateTime.of(2022, 1, 1, 11, 0, 0)
+  private val courtName = "The Court"
+  private val courtId = "TC"
+  private val courtHearingType = CourtHearingType.APPEAL
+  private val prisonId = "WWI"
+  private val startDateTime = LocalDateTime.of(2022, 1, 1, 10, 0, 0)
+  private val endDateTime = LocalDateTime.of(2022, 1, 1, 11, 0, 0)
 
-  var videoLinkBooking =
-    DataHelpers.makeVideoLinkBooking(id = 1L, courtName = COURT_NAME, courtId = COURT_ID, courtHearingType = COURT_HEARING_TYPE, offenderBookingId = 1L, prisonId = PRISON_ID).apply {
-      addPreAppointment(1L, 10L, START_DATE_TIME, END_DATE_TIME)
-      addMainAppointment(2L, 20L, START_DATE_TIME, END_DATE_TIME)
-      addPostAppointment(3L, 30L, START_DATE_TIME, END_DATE_TIME)
+  private val videoLinkBooking =
+    DataHelpers.makeVideoLinkBooking(id = 1L, courtName = courtName, courtId = courtId, courtHearingType = courtHearingType, offenderBookingId = 1L, prisonId = prisonId).apply {
+      addPreAppointment(1L, 10L, startDateTime, endDateTime)
+      addMainAppointment(2L, 20L, startDateTime, endDateTime)
+      addPostAppointment(3L, 30L, startDateTime, endDateTime)
     }
 
   @Test
@@ -49,7 +49,7 @@ class VideoLinkBookingTest {
 
   @Test
   fun `no appointments`() {
-    val vlb = VideoLinkBooking(offenderBookingId = 1L, prisonId = PRISON_ID)
+    val vlb = VideoLinkBooking(offenderBookingId = 1L, prisonId = prisonId)
     assertThat(vlb.appointments[PRE]).isNull()
     assertThat(vlb.appointments[MAIN]).isNull()
     assertThat(vlb.appointments[POST]).isNull()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/AttendanceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/AttendanceServiceTest.kt
@@ -73,13 +73,13 @@ class AttendanceServiceTest {
       comments = "hello",
     )
 
-  private val START = LocalDate.of(2021, 3, 14)
-  private val MOORLAND = "MDI"
+  private val start = LocalDate.of(2021, 3, 14)
+  private val moorland = "MDI"
   private val testAttendanceHistoryDto =
     AttendanceHistoryDto(
-      eventDate = START,
+      eventDate = start,
       comments = "Test comment",
-      location = MOORLAND,
+      location = moorland,
       activity = "a",
       activityDescription = "d",
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/LocationGroupFromElite2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/LocationGroupFromElite2ServiceTest.kt
@@ -10,20 +10,20 @@ class LocationGroupFromElite2ServiceTest {
   private val prisonApiService: PrisonApiService = mock()
   private val service = LocationGroupFromPrisonApiService(prisonApiService)
 
-  private val CELL_A_1: Location =
+  private val cellA1: Location =
     aLocation(locationId = -320L, locationType = "CELL", description = "LEI-A-1-001", parentLocationId = -32L)
-  private val CELL_AA_1: Location =
+  private val cellAA1: Location =
     aLocation(locationId = -320L, locationType = "CELL", description = "LEI-AA-1-001", parentLocationId = -32L)
-  private val CELL_A_3: Location =
+  private val cellA3: Location =
     aLocation(locationId = -320L, locationType = "CELL", description = "LEI-A-3-001", parentLocationId = -32L)
-  private val CELL_B_1: Location =
+  private val cellB1: Location =
     aLocation(locationId = -320L, locationType = "CELL", description = "LEI-B-2-001", parentLocationId = -32L)
 
   @Test
   fun locationGroupFilters() {
     val filter = service.locationGroupFilter("LEI", "A")
-    assertThat(listOf(CELL_A_1, CELL_A_3, CELL_B_1, CELL_AA_1).filter(filter::test))
-      .containsExactlyInAnyOrder(CELL_A_1, CELL_A_3)
+    assertThat(listOf(cellA1, cellA3, cellB1, cellAA1).filter(filter::test))
+      .containsExactlyInAnyOrder(cellA1, cellA3)
   }
 
   private fun aLocation(locationId: Long, locationType: String, description: String, parentLocationId: Long): Location {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/LocationGroupFromPropertiesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/LocationGroupFromPropertiesServiceTest.kt
@@ -234,7 +234,7 @@ class LocationGroupFromPropertiesServiceTest {
       "MDI_2_C",
       "MDI-2-1-0(2[7-9]|3[0-8]),MDI-2-2-0(2[7-9]|3[0-8]),MDI-2-3-0(2[7-9]|3[0-8])",
     )
-    val ONE_A_PREFIXES = arrayOf(
+    val oneAPrefixes = arrayOf(
       "MDI-1-1-001",
       "MDI-1-1-002",
       "MDI-1-1-003",
@@ -272,7 +272,7 @@ class LocationGroupFromPropertiesServiceTest {
       "MDI-1-3-011",
       "MDI-1-3-012",
     )
-    val ONE_B_PREFIXES = arrayOf(
+    val oneBPrefixes = arrayOf(
       "MDI-1-1-013",
       "MDI-1-1-014",
       "MDI-1-1-015",
@@ -316,7 +316,7 @@ class LocationGroupFromPropertiesServiceTest {
       "MDI-1-3-025",
       "MDI-1-3-026",
     )
-    val ONE_C_PREFIXES = arrayOf(
+    val oneCPrefixes = arrayOf(
       "MDI-1-1-027",
       "MDI-1-1-028",
       "MDI-1-1-029",
@@ -358,7 +358,7 @@ class LocationGroupFromPropertiesServiceTest {
       "MDI-1-1-039",
     )
 
-    val locationPrefixes = arrayOf(*ONE_A_PREFIXES, *ONE_B_PREFIXES, *ONE_C_PREFIXES, *extraPrefixes)
+    val locationPrefixes = arrayOf(*oneAPrefixes, *oneBPrefixes, *oneCPrefixes, *extraPrefixes)
     assertThat(
       applyPredicatesToLocations(
         service.locationGroupFilter("MDI", "1"),
@@ -370,19 +370,19 @@ class LocationGroupFromPropertiesServiceTest {
         service.locationGroupFilter("MDI", "1_A"),
         *locationPrefixes,
       ),
-    ).containsExactly(*ONE_A_PREFIXES)
+    ).containsExactly(*oneAPrefixes)
     assertThat(
       applyPredicatesToLocations(
         service.locationGroupFilter("MDI", "1_B"),
         *locationPrefixes,
       ),
-    ).containsExactly(*ONE_B_PREFIXES)
+    ).containsExactly(*oneBPrefixes)
     assertThat(
       applyPredicatesToLocations(
         service.locationGroupFilter("MDI", "1_C"),
         *locationPrefixes,
       ),
-    ).containsExactly(*ONE_C_PREFIXES)
+    ).containsExactly(*oneCPrefixes)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/court/CourtServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/court/CourtServiceTest.kt
@@ -15,14 +15,14 @@ import uk.gov.justice.digital.hmpps.whereabouts.repository.CourtRepository
 
 class CourtServiceTest {
 
-  val repository: CourtRepository = mock()
+  private val repository: CourtRepository = mock()
 
-  val DERBY_JC_ID = "DRBYJC"
-  val DERBY_JC_NAME = "Derby Justice Centre"
-  val DERBY_JC_EMAIL = "derby@derby.org"
+  private val derbyJcId = "DRBYJC"
+  private val derbyJcName = "Derby Justice Centre"
+  private val derbyJcEmail = "derby@derby.org"
 
-  val courts = listOf(
-    Court(DERBY_JC_ID, DERBY_JC_NAME, DERBY_JC_EMAIL),
+  private val courts = listOf(
+    Court(derbyJcId, derbyJcName, derbyJcEmail),
     Court("DUDLMC", "Dudley"),
     Court("HERFCC", "Hereford Crown"),
 
@@ -49,14 +49,14 @@ class CourtServiceTest {
   @Test
   fun `courtNames`() {
     val service = CourtService(repository)
-    assertThat(service.courtNames).containsExactly(DERBY_JC_NAME, "Dudley", "Hereford Crown")
+    assertThat(service.courtNames).containsExactly(derbyJcName, "Dudley", "Hereford Crown")
   }
 
   @Nested
   inner class FindName {
     @Test
     fun `found`() {
-      assertThat(CourtService(repository).getCourtNameForCourtId(DERBY_JC_ID)).isEqualTo(DERBY_JC_NAME)
+      assertThat(CourtService(repository).getCourtNameForCourtId(derbyJcId)).isEqualTo(derbyJcName)
     }
 
     @Test
@@ -69,7 +69,7 @@ class CourtServiceTest {
   inner class FindEmail {
     @Test
     fun `found`() {
-      assertThat(CourtService(repository).getCourtEmailForCourtId(DERBY_JC_ID)).isEqualTo(DERBY_JC_EMAIL)
+      assertThat(CourtService(repository).getCourtEmailForCourtId(derbyJcId)).isEqualTo(derbyJcEmail)
     }
 
     @Test
@@ -82,13 +82,13 @@ class CourtServiceTest {
   inner class FindId {
     @Test
     fun `perfect match`() {
-      assertThat(CourtService(repository).getCourtIdForCourtName(DERBY_JC_NAME)).isEqualTo(DERBY_JC_ID)
+      assertThat(CourtService(repository).getCourtIdForCourtName(derbyJcName)).isEqualTo(derbyJcId)
     }
 
     @Test
     fun `case insensitive match with whitespace`() {
-      assertThat(CourtService(repository).getCourtIdForCourtName(" ${DERBY_JC_NAME.uppercase()}  ")).isEqualTo(
-        DERBY_JC_ID,
+      assertThat(CourtService(repository).getCourtIdForCourtName(" ${derbyJcName.uppercase()}  ")).isEqualTo(
+        derbyJcId,
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/vlboptionsfinder/VideoLinkBookingOptionsFinderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/vlboptionsfinder/VideoLinkBookingOptionsFinderTest.kt
@@ -42,7 +42,7 @@ class VideoLinkBookingOptionsFinderTest {
     Stream.of(
       arguments(
         "Main appointment is available when a room is not booked",
-        specification(main = from(11, 0).until(11, 30).inRoom(Room1)),
+        specification(main = from(11, 0).until(11, 30).inRoom(ROOM_1)),
         emptySchedule(),
         true,
         noOptionsExpected(),
@@ -50,17 +50,17 @@ class VideoLinkBookingOptionsFinderTest {
 
       arguments(
         "Room is occupied all day: No match and no alternatives",
-        specification(main = from(11, 0).until(11, 30).inRoom(Room1)),
-        roomOccupiedAllDay(Room1),
+        specification(main = from(11, 0).until(11, 30).inRoom(ROOM_1)),
+        roomOccupiedAllDay(ROOM_1),
         false,
         noOptionsExpected(),
       ),
 
       arguments(
         "Room booked contiguously before spec: Match expected",
-        specification(main = from(11, 0).until(11, 30).inRoom(Room1)),
+        specification(main = from(11, 0).until(11, 30).inRoom(ROOM_1)),
         schedule(
-          room(Room1).from(10, 50).until(11, 0),
+          room(ROOM_1).from(10, 50).until(11, 0),
         ),
         true,
         noOptionsExpected(),
@@ -68,9 +68,9 @@ class VideoLinkBookingOptionsFinderTest {
 
       arguments(
         "Room booked contiguously after spec: Match expected",
-        specification(main = from(11, 0).until(11, 30).inRoom(Room1)),
+        specification(main = from(11, 0).until(11, 30).inRoom(ROOM_1)),
         schedule(
-          room(Room1).from(11, 30).until(11, 40),
+          room(ROOM_1).from(11, 30).until(11, 40),
         ),
         true,
         noOptionsExpected(),
@@ -78,10 +78,10 @@ class VideoLinkBookingOptionsFinderTest {
 
       arguments(
         "Room booked contiguously before and after spec: Match expected",
-        specification(main = from(11, 0).until(11, 30).inRoom(Room1)),
+        specification(main = from(11, 0).until(11, 30).inRoom(ROOM_1)),
         schedule(
-          room(Room1).from(10, 50).until(11, 0),
-          room(Room1).from(11, 30).until(11, 40),
+          room(ROOM_1).from(10, 50).until(11, 0),
+          room(ROOM_1).from(11, 30).until(11, 40),
         ),
         true,
         noOptionsExpected(),
@@ -89,52 +89,52 @@ class VideoLinkBookingOptionsFinderTest {
 
       arguments(
         "Spec brackets a scheduled appointment: Three alternatives offered.",
-        specification(main = from(11, 0).until(11, 30).inRoom(Room1)),
+        specification(main = from(11, 0).until(11, 30).inRoom(ROOM_1)),
         schedule(
-          room(Room1).from(11, 10).until(11, 20),
+          room(ROOM_1).from(11, 10).until(11, 20),
         ),
         false,
         expectedOptions(
-          option(main = from(10, 15).until(10, 45).inRoom(Room1)),
-          option(main = from(10, 30).until(11, 0).inRoom(Room1)),
-          option(main = from(11, 30).until(12, 0).inRoom(Room1)),
+          option(main = from(10, 15).until(10, 45).inRoom(ROOM_1)),
+          option(main = from(10, 30).until(11, 0).inRoom(ROOM_1)),
+          option(main = from(11, 30).until(12, 0).inRoom(ROOM_1)),
         ),
       ),
 
       arguments(
         "Room fully booked upto and including appointment time. Alternatives offered after spec",
-        specification(main = from(11, 0).until(11, 30).inRoom(Room1)),
+        specification(main = from(11, 0).until(11, 30).inRoom(ROOM_1)),
         schedule(
-          room(Room1).from(startOfDay).until(11, 10),
+          room(ROOM_1).from(startOfDay).until(11, 10),
         ),
         false,
         expectedOptions(
-          option(main = from(11, 15).until(11, 45).inRoom(Room1)),
-          option(main = from(11, 30).until(12, 0).inRoom(Room1)),
-          option(main = from(11, 45).until(12, 15).inRoom(Room1)),
+          option(main = from(11, 15).until(11, 45).inRoom(ROOM_1)),
+          option(main = from(11, 30).until(12, 0).inRoom(ROOM_1)),
+          option(main = from(11, 45).until(12, 15).inRoom(ROOM_1)),
         ),
       ),
 
       arguments(
         "Room fully booked from appointment time to end of day. Alternatives offered preceding spec.",
-        specification(main = from(11, 0).until(11, 30).inRoom(Room1)),
+        specification(main = from(11, 0).until(11, 30).inRoom(ROOM_1)),
         schedule(
-          room(Room1).from(11, 0).until(endOfDay),
+          room(ROOM_1).from(11, 0).until(endOfDay),
         ),
         false,
         expectedOptions(
-          option(main = from(10, 0).until(10, 30).inRoom(Room1)),
-          option(main = from(10, 15).until(10, 45).inRoom(Room1)),
-          option(main = from(10, 30).until(11, 0).inRoom(Room1)),
+          option(main = from(10, 0).until(10, 30).inRoom(ROOM_1)),
+          option(main = from(10, 15).until(10, 45).inRoom(ROOM_1)),
+          option(main = from(10, 30).until(11, 0).inRoom(ROOM_1)),
         ),
       ),
 
       arguments(
         "pre, main and post appointments in different rooms, no scheduled appointments. Match expected",
         specification(
-          pre = from(10, 50).until(11, 0).inRoom(Room2),
-          main = from(11, 0).until(11, 30).inRoom(Room1),
-          post = from(11, 30).until(11, 40).inRoom(Room3),
+          pre = from(10, 50).until(11, 0).inRoom(ROOM_2),
+          main = from(11, 0).until(11, 30).inRoom(ROOM_1),
+          post = from(11, 30).until(11, 40).inRoom(ROOM_3),
         ),
         emptySchedule(),
         true,
@@ -144,11 +144,11 @@ class VideoLinkBookingOptionsFinderTest {
       arguments(
         "pre, main and post appointments in different rooms, pre appointment room fully booked: No match, no alternatives.",
         specification(
-          pre = from(10, 50).until(11, 0).inRoom(Room2),
-          main = from(11, 0).until(11, 30).inRoom(Room1),
-          post = from(11, 30).until(11, 40).inRoom(Room3),
+          pre = from(10, 50).until(11, 0).inRoom(ROOM_2),
+          main = from(11, 0).until(11, 30).inRoom(ROOM_1),
+          post = from(11, 30).until(11, 40).inRoom(ROOM_3),
         ),
-        roomOccupiedAllDay(Room2),
+        roomOccupiedAllDay(ROOM_2),
         false,
         noOptionsExpected(),
       ),
@@ -156,11 +156,11 @@ class VideoLinkBookingOptionsFinderTest {
       arguments(
         "pre, main and post appointments in different rooms, post appointment room fully booked: No match, no alternatives.",
         specification(
-          pre = from(10, 50).until(11, 0).inRoom(Room2),
-          main = from(11, 0).until(11, 30).inRoom(Room1),
-          post = from(11, 30).until(11, 40).inRoom(Room3),
+          pre = from(10, 50).until(11, 0).inRoom(ROOM_2),
+          main = from(11, 0).until(11, 30).inRoom(ROOM_1),
+          post = from(11, 30).until(11, 40).inRoom(ROOM_3),
         ),
-        roomOccupiedAllDay(Room3),
+        roomOccupiedAllDay(ROOM_3),
         false,
         noOptionsExpected(),
       ),
@@ -168,29 +168,29 @@ class VideoLinkBookingOptionsFinderTest {
       arguments(
         "pre, main and post appointments in different rooms, pre room occupied: alternatives offered",
         specification(
-          pre = from(11, 45).until(12, 0).inRoom(Room2),
-          main = from(12, 0).until(12, 30).inRoom(Room1),
-          post = from(12, 30).until(12, 45).inRoom(Room3),
+          pre = from(11, 45).until(12, 0).inRoom(ROOM_2),
+          main = from(12, 0).until(12, 30).inRoom(ROOM_1),
+          post = from(12, 30).until(12, 45).inRoom(ROOM_3),
         ),
         schedule(
-          room(Room2).from(11, 45).until(12, 0),
+          room(ROOM_2).from(11, 45).until(12, 0),
         ),
         false,
         expectedOptions(
           option(
-            pre = from(11, 15).until(11, 30).inRoom(Room2),
-            main = from(11, 30).until(12, 0).inRoom(Room1),
-            post = from(12, 0).until(12, 15).inRoom(Room3),
+            pre = from(11, 15).until(11, 30).inRoom(ROOM_2),
+            main = from(11, 30).until(12, 0).inRoom(ROOM_1),
+            post = from(12, 0).until(12, 15).inRoom(ROOM_3),
           ),
           option(
-            pre = from(11, 30).until(11, 45).inRoom(Room2),
-            main = from(11, 45).until(12, 15).inRoom(Room1),
-            post = from(12, 15).until(12, 30).inRoom(Room3),
+            pre = from(11, 30).until(11, 45).inRoom(ROOM_2),
+            main = from(11, 45).until(12, 15).inRoom(ROOM_1),
+            post = from(12, 15).until(12, 30).inRoom(ROOM_3),
           ),
           option(
-            pre = from(12, 0).until(12, 15).inRoom(Room2),
-            main = from(12, 15).until(12, 45).inRoom(Room1),
-            post = from(12, 45).until(13, 0).inRoom(Room3),
+            pre = from(12, 0).until(12, 15).inRoom(ROOM_2),
+            main = from(12, 15).until(12, 45).inRoom(ROOM_1),
+            post = from(12, 45).until(13, 0).inRoom(ROOM_3),
           ),
         ),
       ),
@@ -198,29 +198,29 @@ class VideoLinkBookingOptionsFinderTest {
       arguments(
         "pre, main and post appointments in different rooms, post room occupied: alternatives offered",
         specification(
-          pre = from(11, 45).until(12, 0).inRoom(Room2),
-          main = from(12, 0).until(12, 30).inRoom(Room1),
-          post = from(12, 30).until(12, 45).inRoom(Room3),
+          pre = from(11, 45).until(12, 0).inRoom(ROOM_2),
+          main = from(12, 0).until(12, 30).inRoom(ROOM_1),
+          post = from(12, 30).until(12, 45).inRoom(ROOM_3),
         ),
         schedule(
-          room(Room3).from(12, 30).until(12, 45),
+          room(ROOM_3).from(12, 30).until(12, 45),
         ),
         false,
         expectedOptions(
           option(
-            pre = from(11, 15).until(11, 30).inRoom(Room2),
-            main = from(11, 30).until(12, 0).inRoom(Room1),
-            post = from(12, 0).until(12, 15).inRoom(Room3),
+            pre = from(11, 15).until(11, 30).inRoom(ROOM_2),
+            main = from(11, 30).until(12, 0).inRoom(ROOM_1),
+            post = from(12, 0).until(12, 15).inRoom(ROOM_3),
           ),
           option(
-            pre = from(11, 30).until(11, 45).inRoom(Room2),
-            main = from(11, 45).until(12, 15).inRoom(Room1),
-            post = from(12, 15).until(12, 30).inRoom(Room3),
+            pre = from(11, 30).until(11, 45).inRoom(ROOM_2),
+            main = from(11, 45).until(12, 15).inRoom(ROOM_1),
+            post = from(12, 15).until(12, 30).inRoom(ROOM_3),
           ),
           option(
-            pre = from(12, 0).until(12, 15).inRoom(Room2),
-            main = from(12, 15).until(12, 45).inRoom(Room1),
-            post = from(12, 45).until(13, 0).inRoom(Room3),
+            pre = from(12, 0).until(12, 15).inRoom(ROOM_2),
+            main = from(12, 15).until(12, 45).inRoom(ROOM_1),
+            post = from(12, 45).until(13, 0).inRoom(ROOM_3),
           ),
         ),
       ),
@@ -228,19 +228,19 @@ class VideoLinkBookingOptionsFinderTest {
       arguments(
         "pre, main and post appointments in different rooms, all rooms occupied except at times in spec: Spec matched",
         specification(
-          pre = from(11, 45).until(12, 0).inRoom(Room2),
-          main = from(12, 0).until(12, 30).inRoom(Room1),
-          post = from(12, 30).until(12, 45).inRoom(Room3),
+          pre = from(11, 45).until(12, 0).inRoom(ROOM_2),
+          main = from(12, 0).until(12, 30).inRoom(ROOM_1),
+          post = from(12, 30).until(12, 45).inRoom(ROOM_3),
         ),
         schedule(
-          room(Room2).from(startOfDay).until(11, 45),
-          room(Room2).from(12, 0).until(endOfDay),
+          room(ROOM_2).from(startOfDay).until(11, 45),
+          room(ROOM_2).from(12, 0).until(endOfDay),
 
-          room(Room1).from(startOfDay).until(12, 0),
-          room(Room1).from(12, 30).until(endOfDay),
+          room(ROOM_1).from(startOfDay).until(12, 0),
+          room(ROOM_1).from(12, 30).until(endOfDay),
 
-          room(Room3).from(startOfDay).until(12, 30),
-          room(Room3).from(12, 45).until(endOfDay),
+          room(ROOM_3).from(startOfDay).until(12, 30),
+          room(ROOM_3).from(12, 45).until(endOfDay),
         ),
         true,
         noOptionsExpected(),
@@ -249,31 +249,31 @@ class VideoLinkBookingOptionsFinderTest {
       arguments(
         "pre, main and post appointments in different rooms each room occupied at different times forcing alternatives to be spread widely",
         specification(
-          pre = from(11, 45).until(12, 0).inRoom(Room2),
-          main = from(12, 0).until(12, 30).inRoom(Room1),
-          post = from(12, 30).until(12, 45).inRoom(Room3),
+          pre = from(11, 45).until(12, 0).inRoom(ROOM_2),
+          main = from(12, 0).until(12, 30).inRoom(ROOM_1),
+          post = from(12, 30).until(12, 45).inRoom(ROOM_3),
         ),
         schedule(
-          room(Room2).from(10, 15).until(12, 0),
-          room(Room1).from(12, 0).until(14, 0),
-          room(Room3).from(14, 45).until(15, 45),
+          room(ROOM_2).from(10, 15).until(12, 0),
+          room(ROOM_1).from(12, 0).until(14, 0),
+          room(ROOM_3).from(14, 45).until(15, 45),
         ),
         false,
         expectedOptions(
           option(
-            pre = from(10, 0).until(10, 15).inRoom(Room2),
-            main = from(10, 15).until(10, 45).inRoom(Room1),
-            post = from(10, 45).until(11, 0).inRoom(Room3),
+            pre = from(10, 0).until(10, 15).inRoom(ROOM_2),
+            main = from(10, 15).until(10, 45).inRoom(ROOM_1),
+            post = from(10, 45).until(11, 0).inRoom(ROOM_3),
           ),
           option(
-            pre = from(13, 45).until(14, 0).inRoom(Room2),
-            main = from(14, 0).until(14, 30).inRoom(Room1),
-            post = from(14, 30).until(14, 45).inRoom(Room3),
+            pre = from(13, 45).until(14, 0).inRoom(ROOM_2),
+            main = from(14, 0).until(14, 30).inRoom(ROOM_1),
+            post = from(14, 30).until(14, 45).inRoom(ROOM_3),
           ),
           option(
-            pre = from(15, 0).until(15, 15).inRoom(Room2),
-            main = from(15, 15).until(15, 45).inRoom(Room1),
-            post = from(15, 45).until(16, 0).inRoom(Room3),
+            pre = from(15, 0).until(15, 15).inRoom(ROOM_2),
+            main = from(15, 15).until(15, 45).inRoom(ROOM_1),
+            post = from(15, 45).until(16, 0).inRoom(ROOM_3),
           ),
         ),
       ),
@@ -281,26 +281,26 @@ class VideoLinkBookingOptionsFinderTest {
       arguments(
         "pre, main and post appointments in different rooms. Rooms occupation prevents match. Only 2 alternatives available.",
         specification(
-          pre = from(11, 45).until(12, 0).inRoom(Room2),
-          main = from(12, 0).until(12, 30).inRoom(Room1),
-          post = from(12, 30).until(12, 45).inRoom(Room3),
+          pre = from(11, 45).until(12, 0).inRoom(ROOM_2),
+          main = from(12, 0).until(12, 30).inRoom(ROOM_1),
+          post = from(12, 30).until(12, 45).inRoom(ROOM_3),
         ),
         schedule(
-          room(Room2).from(10, 15).until(12, 0),
-          room(Room1).from(12, 0).until(14, 0),
-          room(Room3).from(14, 45).until(16, 0),
+          room(ROOM_2).from(10, 15).until(12, 0),
+          room(ROOM_1).from(12, 0).until(14, 0),
+          room(ROOM_3).from(14, 45).until(16, 0),
         ),
         false,
         expectedOptions(
           option(
-            pre = from(10, 0).until(10, 15).inRoom(Room2),
-            main = from(10, 15).until(10, 45).inRoom(Room1),
-            post = from(10, 45).until(11, 0).inRoom(Room3),
+            pre = from(10, 0).until(10, 15).inRoom(ROOM_2),
+            main = from(10, 15).until(10, 45).inRoom(ROOM_1),
+            post = from(10, 45).until(11, 0).inRoom(ROOM_3),
           ),
           option(
-            pre = from(13, 45).until(14, 0).inRoom(Room2),
-            main = from(14, 0).until(14, 30).inRoom(Room1),
-            post = from(14, 30).until(14, 45).inRoom(Room3),
+            pre = from(13, 45).until(14, 0).inRoom(ROOM_2),
+            main = from(14, 0).until(14, 30).inRoom(ROOM_1),
+            post = from(14, 30).until(14, 45).inRoom(ROOM_3),
           ),
         ),
       ),
@@ -308,23 +308,23 @@ class VideoLinkBookingOptionsFinderTest {
       arguments(
         "pre, and main appointments in different rooms. Rooms occupation prevents match. Only 2 alternatives available.",
         specification(
-          pre = from(11, 45).until(12, 0).inRoom(Room2),
-          main = from(12, 0).until(12, 30).inRoom(Room1),
+          pre = from(11, 45).until(12, 0).inRoom(ROOM_2),
+          main = from(12, 0).until(12, 30).inRoom(ROOM_1),
         ),
         schedule(
-          room(Room2).from(10, 15).until(12, 0),
-          room(Room1).from(12, 0).until(14, 0),
-          room(Room1).from(14, 30).until(endOfDay),
+          room(ROOM_2).from(10, 15).until(12, 0),
+          room(ROOM_1).from(12, 0).until(14, 0),
+          room(ROOM_1).from(14, 30).until(endOfDay),
         ),
         false,
         expectedOptions(
           option(
-            pre = from(10, 0).until(10, 15).inRoom(Room2),
-            main = from(10, 15).until(10, 45).inRoom(Room1),
+            pre = from(10, 0).until(10, 15).inRoom(ROOM_2),
+            main = from(10, 15).until(10, 45).inRoom(ROOM_1),
           ),
           option(
-            pre = from(13, 45).until(14, 0).inRoom(Room2),
-            main = from(14, 0).until(14, 30).inRoom(Room1),
+            pre = from(13, 45).until(14, 0).inRoom(ROOM_2),
+            main = from(14, 0).until(14, 30).inRoom(ROOM_1),
           ),
         ),
       ),
@@ -332,18 +332,18 @@ class VideoLinkBookingOptionsFinderTest {
       arguments(
         "main and post appointments in different rooms. Rooms occupation prevents match. Only 1 alternative available.",
         specification(
-          main = from(12, 0).until(12, 30).inRoom(Room1),
-          post = from(12, 30).until(12, 45).inRoom(Room3),
+          main = from(12, 0).until(12, 30).inRoom(ROOM_1),
+          post = from(12, 30).until(12, 45).inRoom(ROOM_3),
         ),
         schedule(
-          room(Room1).from(startOfDay).until(14, 0),
-          room(Room3).from(14, 45).until(16, 0),
+          room(ROOM_1).from(startOfDay).until(14, 0),
+          room(ROOM_3).from(14, 45).until(16, 0),
         ),
         false,
         expectedOptions(
           option(
-            main = from(14, 0).until(14, 30).inRoom(Room1),
-            post = from(14, 30).until(14, 45).inRoom(Room3),
+            main = from(14, 0).until(14, 30).inRoom(ROOM_1),
+            post = from(14, 30).until(14, 45).inRoom(ROOM_3),
           ),
         ),
       ),
@@ -351,15 +351,15 @@ class VideoLinkBookingOptionsFinderTest {
       arguments(
         "pre, main and post appointments in same room with gaps. schedule matches exactly",
         specification(
-          pre = from(11, 45).until(12, 0).inRoom(Room1),
-          main = from(12, 15).until(12, 30).inRoom(Room1),
-          post = from(12, 45).until(13, 0).inRoom(Room1),
+          pre = from(11, 45).until(12, 0).inRoom(ROOM_1),
+          main = from(12, 15).until(12, 30).inRoom(ROOM_1),
+          post = from(12, 45).until(13, 0).inRoom(ROOM_1),
         ),
         schedule(
-          room(Room1).from(startOfDay).until(11, 45),
-          room(Room1).from(12, 0).until(12, 15),
-          room(Room1).from(12, 30).until(12, 45),
-          room(Room1).from(13, 0).until(endOfDay),
+          room(ROOM_1).from(startOfDay).until(11, 45),
+          room(ROOM_1).from(12, 0).until(12, 15),
+          room(ROOM_1).from(12, 30).until(12, 45),
+          room(ROOM_1).from(13, 0).until(endOfDay),
         ),
         true,
         noOptionsExpected(),
@@ -373,9 +373,9 @@ class VideoLinkBookingOptionsFinderTest {
 
     private val agencyId = "AGYID"
 
-    private const val Room1 = 1L
-    private const val Room2 = 2L
-    private const val Room3 = 3L
+    private const val ROOM_1 = 1L
+    private const val ROOM_2 = 2L
+    private const val ROOM_3 = 3L
 
     val tenUntilFourInQuarterHoursGenerator = OptionsGenerator(
       dayStart = startOfDay,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/vlboptionsfinder/VideoLinkBookingOptionsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/vlboptionsfinder/VideoLinkBookingOptionsServiceTest.kt
@@ -38,10 +38,10 @@ class VideoLinkBookingOptionsServiceTest {
       service()
         .findVideoLinkBookingOptions(
           VideoLinkBookingSearchSpecification(
-            date = SEARCH_DATE,
+            date = searchDate,
             agencyId = AGENCY_ID,
             preAppointment = null,
-            mainAppointment = LocationAndInterval(location1, dontCareInterval),
+            mainAppointment = LocationAndInterval(LOCATION_1, dontCareInterval),
           ),
         ),
     ).isEqualTo(theResult)
@@ -67,16 +67,16 @@ class VideoLinkBookingOptionsServiceTest {
       )
 
     val specification = VideoLinkBookingSearchSpecification(
-      date = SEARCH_DATE,
+      date = searchDate,
       agencyId = AGENCY_ID,
       preAppointment = null,
-      mainAppointment = LocationAndInterval(location1, dontCareInterval),
+      mainAppointment = LocationAndInterval(LOCATION_1, dontCareInterval),
     )
 
     service().findVideoLinkBookingOptions(specification)
 
     verify {
-      prisonApiService.getScheduledAppointments(eq(AGENCY_ID), eq(SEARCH_DATE), isNull(), eq(location1))
+      prisonApiService.getScheduledAppointments(eq(AGENCY_ID), eq(searchDate), isNull(), eq(LOCATION_1))
     }
 
     verify {
@@ -115,11 +115,11 @@ class VideoLinkBookingOptionsServiceTest {
       )
 
     val specification = VideoLinkBookingSearchSpecification(
-      date = SEARCH_DATE,
+      date = searchDate,
       agencyId = AGENCY_ID,
       preAppointment = null,
-      mainAppointment = LocationAndInterval(location1, dontCareInterval),
-      vlbIdToExclude = excludedVideoLinkBookingId,
+      mainAppointment = LocationAndInterval(LOCATION_1, dontCareInterval),
+      vlbIdToExclude = EXCLUDED_VIDEO_LINK_BOOKING_ID,
     )
     service().findVideoLinkBookingOptions(specification)
 
@@ -131,7 +131,7 @@ class VideoLinkBookingOptionsServiceTest {
         )
     }
 
-    verify { videoLinkBookingRepository.findById(excludedVideoLinkBookingId) }
+    verify { videoLinkBookingRepository.findById(EXCLUDED_VIDEO_LINK_BOOKING_ID) }
   }
 
   @Test
@@ -149,34 +149,34 @@ class VideoLinkBookingOptionsServiceTest {
       Optional.of(excludedVideoLinkBooking)
 
     every {
-      prisonApiService.getScheduledAppointments(any(), any(), isNull(), location1)
+      prisonApiService.getScheduledAppointments(any(), any(), isNull(), LOCATION_1)
     } returns
       listOf(appt_location1_excl_main, appt2_location1)
 
     every {
-      prisonApiService.getScheduledAppointments(any(), any(), isNull(), location2)
+      prisonApiService.getScheduledAppointments(any(), any(), isNull(), LOCATION_2)
     } returns
       listOf(appt_location2_excl_pre, appt2_location2)
 
     every {
-      prisonApiService.getScheduledAppointments(any(), any(), isNull(), location3)
+      prisonApiService.getScheduledAppointments(any(), any(), isNull(), LOCATION_3)
     } returns
       listOf(appt_location3_excl_post, appt2_location3)
 
     val specification = VideoLinkBookingSearchSpecification(
-      date = SEARCH_DATE,
+      date = searchDate,
       agencyId = AGENCY_ID,
-      preAppointment = LocationAndInterval(location2, dontCareInterval),
-      mainAppointment = LocationAndInterval(location1, dontCareInterval),
-      postAppointment = LocationAndInterval(location3, dontCareInterval),
-      vlbIdToExclude = excludedVideoLinkBookingId,
+      preAppointment = LocationAndInterval(LOCATION_2, dontCareInterval),
+      mainAppointment = LocationAndInterval(LOCATION_1, dontCareInterval),
+      postAppointment = LocationAndInterval(LOCATION_3, dontCareInterval),
+      vlbIdToExclude = EXCLUDED_VIDEO_LINK_BOOKING_ID,
     )
 
     service().findVideoLinkBookingOptions(specification)
 
-    verify { prisonApiService.getScheduledAppointments(AGENCY_ID, SEARCH_DATE, null, location1) }
-    verify { prisonApiService.getScheduledAppointments(AGENCY_ID, SEARCH_DATE, null, location2) }
-    verify { prisonApiService.getScheduledAppointments(AGENCY_ID, SEARCH_DATE, null, location3) }
+    verify { prisonApiService.getScheduledAppointments(AGENCY_ID, searchDate, null, LOCATION_1) }
+    verify { prisonApiService.getScheduledAppointments(AGENCY_ID, searchDate, null, LOCATION_2) }
+    verify { prisonApiService.getScheduledAppointments(AGENCY_ID, searchDate, null, LOCATION_3) }
 
     verify {
       videoLinkBookingOptionsFinder
@@ -193,40 +193,40 @@ class VideoLinkBookingOptionsServiceTest {
 
   companion object {
     const val DONT_CARE = "Don't care"
-    const val excludedVideoLinkBookingId = 100L
-    const val excludedMainAppointmentId = 1L
-    const val excludedPreAppointmentId = 2L
-    const val excludedPostAppointmentId = 3L
+    const val EXCLUDED_VIDEO_LINK_BOOKING_ID = 100L
+    const val EXCLUDED_MAIN_APPOINTMENT_ID = 1L
+    const val EXCLUDED_PRE_APPOINTMENT_ID = 2L
+    const val EXCLUDED_POST_APPOINTMENT_ID = 3L
 
-    const val location1 = 11L
-    const val location2 = 12L
-    const val location3 = 13L
+    const val LOCATION_1 = 11L
+    const val LOCATION_2 = 12L
+    const val LOCATION_3 = 13L
 
     // Tests aren't concerned with the following values
-    val SEARCH_DATE: LocalDate = LocalDate.of(2020, 1, 1)
+    val searchDate: LocalDate = LocalDate.of(2020, 1, 1)
     val dontCareTime: LocalTime = LocalTime.of(9, 0)
-    val dontCareDateTime: LocalDateTime = SEARCH_DATE.atTime(dontCareTime)
+    val dontCareDateTime: LocalDateTime = searchDate.atTime(dontCareTime)
 
     const val AGENCY_ID = "WWI"
     val startDateTime = LocalDateTime.of(2022, 1, 1, 10, 0, 0)
     val endDateTime = LocalDateTime.of(2022, 1, 1, 11, 0, 0)
-    const val dontCareOffenderNo = "C3456CC"
+    const val DONT_CARE_OFFENDER_NO = "C3456CC"
     val dontCareInterval = Interval(dontCareTime, dontCareTime)
 
     // appointmentTypeCode doesn't matter. All appointments for a room make the room unavailable.
-    val appt1_location1 = appointmentDto(location1, excludedMainAppointmentId, "VLAA")
-    val appt2_location1 = appointmentDto(location1, 20L)
+    val appt1_location1 = appointmentDto(LOCATION_1, EXCLUDED_MAIN_APPOINTMENT_ID, "VLAA")
+    val appt2_location1 = appointmentDto(LOCATION_1, 20L)
 
     // Always excluded because endTime == null
     val appt3_location1_no_end_time =
       ScheduledAppointmentSearchDto(
         id = 30L,
         agencyId = AGENCY_ID,
-        locationId = location1,
+        locationId = LOCATION_1,
         appointmentTypeCode = "VLB",
         startTime = dontCareDateTime,
         endTime = null,
-        offenderNo = dontCareOffenderNo,
+        offenderNo = DONT_CARE_OFFENDER_NO,
         appointmentTypeDescription = DONT_CARE,
         createUserId = DONT_CARE,
         firstName = DONT_CARE,
@@ -234,36 +234,36 @@ class VideoLinkBookingOptionsServiceTest {
         locationDescription = DONT_CARE,
       )
 
-    val appt1_location2 = appointmentDto(location2, excludedPreAppointmentId)
-    val appt2_location2 = appointmentDto(location2, 40L)
+    val appt1_location2 = appointmentDto(LOCATION_2, EXCLUDED_PRE_APPOINTMENT_ID)
+    val appt2_location2 = appointmentDto(LOCATION_2, 40L)
 
-    val appt1_location3 = appointmentDto(location3, excludedPostAppointmentId)
-    val appt2_location3 = appointmentDto(location3, 50L)
+    val appt1_location3 = appointmentDto(LOCATION_3, EXCLUDED_POST_APPOINTMENT_ID)
+    val appt2_location3 = appointmentDto(LOCATION_3, 50L)
 
     val appt_location1_excl_main = appt1_location1
     val appt_location2_excl_pre = appt1_location2
     val appt_location3_excl_post = appt1_location3
 
     val excludedVideoLinkBookingMainOnly = DataHelpers.makeVideoLinkBooking(
-      id = excludedVideoLinkBookingId,
+      id = EXCLUDED_VIDEO_LINK_BOOKING_ID,
       offenderBookingId = 999L,
       courtName = DONT_CARE,
       courtId = DONT_CARE,
       prisonId = AGENCY_ID,
     ).apply {
-      addMainAppointment(excludedMainAppointmentId, 20L, startDateTime, endDateTime, 9999L)
+      addMainAppointment(EXCLUDED_MAIN_APPOINTMENT_ID, 20L, startDateTime, endDateTime, 9999L)
     }
 
     val excludedVideoLinkBooking = DataHelpers.makeVideoLinkBooking(
-      id = excludedVideoLinkBookingId,
+      id = EXCLUDED_VIDEO_LINK_BOOKING_ID,
       offenderBookingId = 999L,
       courtName = DONT_CARE,
       courtId = DONT_CARE,
       prisonId = AGENCY_ID,
     ).apply {
-      addMainAppointment(excludedMainAppointmentId, 20L, startDateTime, endDateTime, 9999L)
-      addPreAppointment(excludedPreAppointmentId, 20L, startDateTime, endDateTime, 9998L)
-      addPostAppointment(excludedPostAppointmentId, 20L, startDateTime, endDateTime, 9997L)
+      addMainAppointment(EXCLUDED_MAIN_APPOINTMENT_ID, 20L, startDateTime, endDateTime, 9999L)
+      addPreAppointment(EXCLUDED_PRE_APPOINTMENT_ID, 20L, startDateTime, endDateTime, 9998L)
+      addPostAppointment(EXCLUDED_POST_APPOINTMENT_ID, 20L, startDateTime, endDateTime, 9997L)
     }
 
     fun appointmentDto(locationId: Long, id: Long, appointmentTypeCode: String = "VLB"): ScheduledAppointmentSearchDto =
@@ -274,7 +274,7 @@ class VideoLinkBookingOptionsServiceTest {
         appointmentTypeCode = appointmentTypeCode,
         startTime = dontCareDateTime,
         endTime = dontCareDateTime,
-        offenderNo = dontCareOffenderNo,
+        offenderNo = DONT_CARE_OFFENDER_NO,
         appointmentTypeDescription = DONT_CARE,
         createUserId = DONT_CARE,
         firstName = DONT_CARE,

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -57,3 +57,7 @@ courts: Test Court 1,Test Court 2
 
 server:
   shutdown: immediate
+
+feature:
+  bvls:
+    enabled: true


### PR DESCRIPTION
This change introduces a feature switch to turn off the listening to BVLS related events when the new replatformed BLVS service is made available in production.

When the new service is available it will be solely responsible for the processing of these events.

Note: this change also includes some unrelated linting fixes that showed up when compiling existing code (it was annoying me!)