### PR TITLE
BAVL-251 trial the turning off processing of events for BLVS in dev.

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -11,6 +11,7 @@ generic-service:
     SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth/.well-known/jwks.json"
     NOTIFY_ENABLED: true
     PRISONREGISTER_ENDPOINT_URL: "https://prison-register-dev.hmpps.service.justice.gov.uk"
+    FEATURE_BVLS_ENABLED: "false"
 
   allowlist:
     groups:

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/listeners/SqsDomainEventListener.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/listeners/SqsDomainEventListener.kt
@@ -46,6 +46,8 @@ class SqsDomainEventListener(
         log.error("processDomainEvent() Unexpected error", e)
         throw e
       }
+    } else {
+      log.info("Ignoring domain events for BVLS, BVLS feature is disabled.")
     }
   }
 }

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/listeners/SqsOffenderEventListener.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/listeners/SqsOffenderEventListener.kt
@@ -53,6 +53,8 @@ class SqsOffenderEventListener(
           if (bvlsEnabled) {
             val appointmentChangedEventMessage = gson.fromJson(message, AppointmentChangedEventMessage::class.java)
             videoLinkBookingService.processNomisUpdate(appointmentChangedEventMessage)
+          } else {
+            log.info("Ignoring offender event appointment changed for BVLS, BVLS feature is disabled.")
           }
         }
       }


### PR DESCRIPTION
This is trial run turning off of the BVLS feature flag which basically means ignoring certain events/messages for BVLS.

These events are to be processed by the re-platformed BLVS service when it goes live.

Events will not end up on the DLQ as they are still consumed but no processing is done on the back of receiving them.

Note this is in DEV only and will not impact preprod or prod, i.e it can be released to prod with this change if need be.

When confirmed as working a separate PR will be raised to turn it back on.