### PR TITLE
BAVL-251 turning flag back on for processing of events for BLVS in dev.

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -11,7 +11,6 @@ generic-service:
     SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth/.well-known/jwks.json"
     NOTIFY_ENABLED: true
     PRISONREGISTER_ENDPOINT_URL: "https://prison-register-dev.hmpps.service.justice.gov.uk"
-    FEATURE_BVLS_ENABLED: "false"
 
   allowlist:
     groups:


### PR DESCRIPTION
This is reverting this (trial) feature flag change on a previous PR [here](https://github.com/ministryofjustice/whereabouts-api/pull/691). 