### PR TITLE
MAP-1557 change webclient options for a single endpoint

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/controllers/VideoLinkBookingRoomsController.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/controllers/VideoLinkBookingRoomsController.kt
@@ -19,7 +19,6 @@ class VideoLinkBookingRoomsController(
   private val locationService: LocationService,
 
 ) {
-
   @GetMapping(
     path = ["/video-link-rooms/{agencyId}"],
     produces = [MediaType.APPLICATION_JSON_VALUE],

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/PrisonApi.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/PrisonApi.java
@@ -270,7 +270,7 @@ public abstract class PrisonApi {
                 e -> Mono.error(e.getStatusCode().value() == 423 ? new DatabaseRowLockedException() : e)
             )
             .retry(3)
-            .timeout(Duration.ofSeconds(1))
+            .timeout(Duration.ofSeconds(12))
             .block();
     }
 

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/PrisonApi.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/PrisonApi.java
@@ -33,6 +33,7 @@ import uk.gov.justice.digital.hmpps.whereabouts.model.PrisonAppointment;
 import uk.gov.justice.digital.hmpps.whereabouts.model.TimePeriod;
 import uk.gov.justice.digital.hmpps.whereabouts.services.court.UpdateComment;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
@@ -268,6 +269,8 @@ public abstract class PrisonApi {
                 WebClientResponseException.class,
                 e -> Mono.error(e.getStatusCode().value() == 423 ? new DatabaseRowLockedException() : e)
             )
+            .retry(3)
+            .timeout(Duration.ofSeconds(1))
             .block();
     }
 


### PR DESCRIPTION
Calling /make-cell-move results in prisonApiService.putCellMove() call. 
Slow network could be the reason for the call to prison api returning 500 errors. 
Implemented shorter timeouts with greater retries.