### PR TITLE
Disable IWI in whereabouts due to DPS A&A rollout

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -14,5 +14,5 @@ generic-service:
     SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth/.well-known/jwks.json"
     NOTIFY_ENABLED: false
     PRISONREGISTER_ENDPOINT_URL: "https://prison-register-preprod.hmpps.service.justice.gov.uk"
-    WHEREABOUTS_DISABLED: RSI,WDI,LPI
+    WHEREABOUTS_DISABLED: RSI,WDI,LPI,FMI,IWI
 

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -13,7 +13,7 @@ generic-service:
     SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI: "https://sign-in.hmpps.service.justice.gov.uk/auth/.well-known/jwks.json"
     NOTIFY_ENABLED: true
     PRISONREGISTER_ENDPOINT_URL: "https://prison-register.hmpps.service.justice.gov.uk"
-    WHEREABOUTS_DISABLED: RSI,WDI,LPI,FMI
+    WHEREABOUTS_DISABLED: RSI,WDI,LPI,FMI,IWI
 
   postgresDatabaseRestore:
     enabled: true


### PR DESCRIPTION
Should be merged as part of the A&A rollout process for IWI on Sep 20th (target date, may get put back). Now 27th

Also a minor change in here that will bring the preprod env up to date with the prod env for this rollout for IWI, and previously migrated Feltham FMI