### PR TITLE
BAVL-42: Cater for cancelled bookings having their video_link_booking row not present

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/VideoLinkMigrationService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/VideoLinkMigrationService.kt
@@ -31,40 +31,73 @@ class VideoLinkMigrationService(
 
   @Transactional(readOnly = true)
   fun getVideoLinkBookingToMigrate(videoBookingId: Long): VideoBookingMigrateResponse {
-    val videoLinkBooking = videoLinkBookingRepository.findById(videoBookingId)
-      .orElseThrow { EntityNotFoundException("Video link booking ID {videoBookingId} was not found") }
-
-    log.info("Migrating video link booking ID $videoBookingId")
-
-    // Get the history of events for this booking
+    // Get the events for this booking - deleted bookings have no video_link_booking or video_link_appointments
     val eventEntities = videoLinkBookingEventRepository.findEventsByVideoLinkBookingId(videoBookingId)
     require(eventEntities.isNotEmpty()) { "Video link booking ID $videoBookingId has no events" }
 
-    // Is this a cancelled booking? i.e. containing a DELETE event.
+    // Does a DELETE event exist?
     val cancelledBooking = eventEntities.any { it.eventType == VideoLinkBookingEventType.DELETE }
 
-    // Get the appointments linked to the booking - cancelled bookings will have none (they get removed)
-    val appointments = videoLinkAppointmentRepository.findAllByVideoLinkBooking(videoLinkBooking)
+    log.info("Migrating video link booking ID $videoBookingId (cancelled?=$cancelledBooking)")
 
-    if (!cancelledBooking) {
-      require(appointments.isNotEmpty()) { "Video link booking ID $videoBookingId has no appointments" }
-      require((appointments.size <= 3)) { "Video link booking ID $videoBookingId has more than 3 appointments" }
+    return if (cancelledBooking) {
+      cancelledVideoLinkBooking(videoBookingId, eventEntities)
+    } else {
+      activeVideoLinkBooking(videoBookingId, eventEntities)
     }
+  }
 
-    // Extract the related appointments - will be null if a cancelled booking otherwise reflect the appointments
+  fun cancelledVideoLinkBooking(
+    videoBookingId: Long,
+    eventEntities: List<VideoLinkBookingEvent>,
+  ): VideoBookingMigrateResponse {
+    val createEvent = eventEntities.first { it.eventType == VideoLinkBookingEventType.CREATE }
+    val lastChangeEvent = eventEntities.sortedBy { it.timestamp }.last { it.eventType != VideoLinkBookingEventType.DELETE }
+
+    // Reconstruct the appointment detail from the latest CREATE or UPDATE event
+    val appointmentsFromEvent = extractAppointmentsFromEvent(eventEntities)
+
+    // Reconstruct the booking details from the events
+    val bookingDetails = extractBookingFromEvents(createEvent, lastChangeEvent)
+
+    return VideoBookingMigrateResponse(
+      videoBookingId = videoBookingId,
+      offenderBookingId = bookingDetails.offenderBookingId,
+      courtCode = bookingDetails.courtId ?: "UNKNOWN",
+      courtName = bookingDetails.courtName,
+      madeByTheCourt = bookingDetails.madeByTheCourt,
+      createdByUsername = bookingDetails.createdByUsername,
+      prisonCode = bookingDetails.prisonId,
+      probation = bookingDetails.courtName?.contains("Probation") ?: false,
+      cancelled = true,
+      comment = bookingDetails.comment,
+      pre = appointmentsFromEvent.pre,
+      main = appointmentsFromEvent.main!!,
+      post = appointmentsFromEvent.post,
+      events = mapEvents(eventEntities),
+    )
+  }
+
+  fun activeVideoLinkBooking(
+    videoBookingId: Long,
+    eventEntities: List<VideoLinkBookingEvent>,
+  ): VideoBookingMigrateResponse {
+    val videoLinkBooking = videoLinkBookingRepository.findById(videoBookingId)
+      .orElseThrow { EntityNotFoundException("Video link booking ID $videoBookingId was not found") }
+
+    val appointments = videoLinkAppointmentRepository.findAllByVideoLinkBooking(videoLinkBooking)
+    require(appointments.isNotEmpty()) { "Video link booking ID $videoBookingId has no appointments" }
+    require((appointments.size <= 3)) { "Video link booking ID $videoBookingId has more than 3 appointments" }
+
+    // Extract the related appointments, if they exist - but pre and post may be null
     val main = appointments.find { it.hearingType == HearingType.MAIN }
     val pre = appointments.find { it.hearingType == HearingType.PRE }
     val post = appointments.find { it.hearingType == HearingType.POST }
 
-    // Extract appointment details from the latest CREATE or UPDATE event if this booking is cancelled
-    val appointmentsFromEvent = extractAppointmentsFromEvent(eventEntities, cancelledBooking)
-
-    if (!cancelledBooking) {
-      require(main != null) { "Video link booking ID $videoBookingId has no main appointment" }
-    }
+    require(main != null) { "Video link booking ID $videoBookingId has no main appointment" }
 
     return VideoBookingMigrateResponse(
-      videoBookingId = videoLinkBooking.id!!,
+      videoBookingId = videoBookingId,
       offenderBookingId = videoLinkBooking.offenderBookingId,
       courtCode = videoLinkBooking.courtId ?: "UNKNOWN",
       courtName = videoLinkBooking.courtName,
@@ -72,11 +105,11 @@ class VideoLinkMigrationService(
       createdByUsername = videoLinkBooking.createdByUsername ?: "MIGRATED",
       prisonCode = videoLinkBooking.prisonId,
       probation = videoLinkBooking.courtName?.contains("Probation") ?: false,
-      cancelled = cancelledBooking,
+      cancelled = false,
       comment = videoLinkBooking.comment,
-      pre = if (!cancelledBooking) pre?.let { mapAppointment(pre) } else appointmentsFromEvent.pre,
-      main = if (!cancelledBooking) mapAppointment(main!!) else appointmentsFromEvent.main!!,
-      post = if (!cancelledBooking) post?.let { mapAppointment(post) } else appointmentsFromEvent.post,
+      pre = pre?.let { mapAppointment(pre) },
+      main = mapAppointment(main),
+      post = post?.let { mapAppointment(post) },
       events = mapEvents(eventEntities),
     )
   }
@@ -97,8 +130,8 @@ class VideoLinkMigrationService(
       endTime = LocalTime.of(endTime.hour, endTime.minute),
     )
 
-  private fun mapEvents(events: List<VideoLinkBookingEvent>): List<VideoBookingMigrateEvent> {
-    val response = events.map { event ->
+  private fun mapEvents(events: List<VideoLinkBookingEvent>): List<VideoBookingMigrateEvent> =
+    events.map { event ->
       VideoBookingMigrateEvent(
         eventId = event.eventId!!,
         eventTime = event.timestamp,
@@ -115,17 +148,8 @@ class VideoLinkMigrationService(
       )
     }
 
-    return response
-  }
-
-  private fun extractAppointmentsFromEvent(
-    eventEntities: List<VideoLinkBookingEvent>,
-    cancelled: Boolean,
-  ): AppointmentsFromEvent {
+  private fun extractAppointmentsFromEvent(eventEntities: List<VideoLinkBookingEvent>): AppointmentsFromEvent {
     val latestEvent = eventEntities.sortedBy { it.timestamp }.last { it.eventType != VideoLinkBookingEventType.DELETE }
-    if (!cancelled) {
-      return AppointmentsFromEvent()
-    }
     val pre = latestEvent.preLocationId?.let {
       mapEventToLocationTimeSlot(it, latestEvent.preStartTime!!, latestEvent.preEndTime!!)
     }
@@ -137,10 +161,31 @@ class VideoLinkMigrationService(
     }
     return AppointmentsFromEvent(pre, main, post)
   }
+
+  private fun extractBookingFromEvents(createEvent: VideoLinkBookingEvent, lastChangeEvent: VideoLinkBookingEvent) =
+    BookingDetails(
+      offenderBookingId = createEvent.offenderBookingId!!,
+      courtId = lastChangeEvent.courtId,
+      courtName = lastChangeEvent.court,
+      madeByTheCourt = lastChangeEvent.madeByTheCourt!!,
+      prisonId = lastChangeEvent.agencyId!!,
+      createdByUsername = createEvent.userId!!,
+      comment = lastChangeEvent.comment,
+    )
 }
 
 data class AppointmentsFromEvent(
   val pre: AppointmentLocationTimeSlot? = null,
   val main: AppointmentLocationTimeSlot? = null,
   val post: AppointmentLocationTimeSlot? = null,
+)
+
+data class BookingDetails(
+  val offenderBookingId: Long,
+  val courtId: String? = null,
+  val courtName: String? = null,
+  val madeByTheCourt: Boolean = true,
+  val prisonId: String,
+  val createdByUsername: String,
+  val comment: String? = null,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/integration/VideoLinkMigrateIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/integration/VideoLinkMigrateIntegrationTest.kt
@@ -97,7 +97,7 @@ class VideoLinkMigrateIntegrationTest : IntegrationTest() {
         VideoLinkBookingEventType.CREATE,
         VideoLinkBookingEventType.DELETE,
       )
-      assertThat(courtCode).isEqualTo("CVNTCC")
+      assertThat(courtCode).isEqualTo("UNKNOWN")
       assertThat(madeByTheCourt).isTrue
       assertThat(probation).isFalse
       assertThat(prisonCode).isEqualTo("MDI")
@@ -193,16 +193,17 @@ class VideoLinkMigrateIntegrationTest : IntegrationTest() {
   }
 
   private fun makeABooking(cancelled: Boolean = false, updated: Boolean = false) {
-    jdbcTemplate.update(
-      """
-      INSERT INTO video_link_booking (id, offender_booking_id, court_name, court_id, court_hearing_type, made_by_the_court, prison_id, comment)             
-      VALUES (1, 1, 'CVNTCC', 'CVNTCC', 'APPEAL', true, 'MDI', 'Comment')
-      """,
-    )
-
+    // Cancelled bookings only have events - no video_link_booking or video_link_appointment rows
     makeEvents(cancelled, updated)
 
     if (!cancelled) {
+      jdbcTemplate.update(
+        """
+      INSERT INTO video_link_booking (id, offender_booking_id, court_name, court_id, court_hearing_type, made_by_the_court, prison_id, comment)             
+      VALUES (1, 1, 'CVNTCC', 'CVNTCC', 'APPEAL', true, 'MDI', 'Comment')
+      """,
+      )
+
       val appointmentTime = LocalDateTime.of(2023, 11, 10, 10, 30)
       makeAppointment(appointmentTime)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/VideoLinkMigrationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/VideoLinkMigrationServiceTest.kt
@@ -4,6 +4,8 @@ import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.whereabouts.model.HearingType
 import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkAppointment
@@ -194,18 +196,13 @@ class VideoLinkMigrationServiceTest {
       comment = "hello",
     )
 
-    // No appointments
-    val appointments: List<VideoLinkAppointment> = emptyList()
-
     // Events include create, update and delete
     val events = listOf(
-      makeEvent(3L, 1L, VideoLinkBookingEventType.CREATE),
+      makeEvent(3L, 1L, VideoLinkBookingEventType.CREATE, "YORKMAGS", "York Justice Centre"),
       makeEvent(3L, 1L, VideoLinkBookingEventType.UPDATE),
       makeEvent(3L, 1L, VideoLinkBookingEventType.DELETE),
     )
 
-    whenever(videoLinkBookingRepository.findById(videoBookingId)).thenReturn(Optional.of(booking))
-    whenever(videoLinkAppointmentRepository.findAllByVideoLinkBooking(booking)).thenReturn(appointments)
     whenever(videoLinkBookingEventRepository.findEventsByVideoLinkBookingId(videoBookingId)).thenReturn(events)
 
     val response = videoLinkMigrationService.getVideoLinkBookingToMigrate(3)
@@ -228,6 +225,10 @@ class VideoLinkMigrationServiceTest {
     assertThat(response.main.endTime).isNotNull()
 
     assertThat(response.post).isNull()
+
+    verify(videoLinkBookingEventRepository).findEventsByVideoLinkBookingId(videoBookingId)
+    verifyNoInteractions(videoLinkBookingRepository)
+    verifyNoInteractions(videoLinkAppointmentRepository)
   }
 
   @Test


### PR DESCRIPTION
When a video link booking is cancelled, the video link booking row is fully removed from the database.
This change will reconstruct the booking details from the events which remain.