### PR TITLE
BAVL-41: Migration trigger to select bookings and emit domain events

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -11,6 +11,7 @@ generic-service:
     SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth/.well-known/jwks.json"
     NOTIFY_ENABLED: true
     PRISONREGISTER_ENDPOINT_URL: "https://prison-register-dev.hmpps.service.justice.gov.uk"
+    FEATURE_EVENTS_SNS_ENABLED: true
 
   allowlist:
     groups:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -15,4 +15,5 @@ generic-service:
     NOTIFY_ENABLED: false
     PRISONREGISTER_ENDPOINT_URL: "https://prison-register-preprod.hmpps.service.justice.gov.uk"
     WHEREABOUTS_DISABLED: RSI,WDI,LPI
+    FEATURE_EVENTS_SNS_ENABLED: false
 

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -15,5 +15,5 @@ generic-service:
     NOTIFY_ENABLED: false
     PRISONREGISTER_ENDPOINT_URL: "https://prison-register-preprod.hmpps.service.justice.gov.uk"
     WHEREABOUTS_DISABLED: RSI,WDI,LPI
-    FEATURE_EVENTS_SNS_ENABLED: false
+    FEATURE_EVENTS_SNS_ENABLED: true
 

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -14,6 +14,7 @@ generic-service:
     NOTIFY_ENABLED: true
     PRISONREGISTER_ENDPOINT_URL: "https://prison-register.hmpps.service.justice.gov.uk"
     WHEREABOUTS_DISABLED: RSI,WDI,LPI,FMI
+    FEATURE_EVENTS_SNS_ENABLED: false
 
   postgresDatabaseRestore:
     enabled: true

--- a/helm_deploy/whereabouts-api/values.yaml
+++ b/helm_deploy/whereabouts-api/values.yaml
@@ -37,6 +37,8 @@ generic-service:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     HMPPS_SQS_USE_WEB_TOKEN: "true"
     FEATURE_BVLS_ENABLED: "true"
+    FEATURE_EVENTS_SNS_ENABLED: false
+    FEATURE_EVENT_VIDEO_LINK_BOOKING_MIGRATE: true
 
   namespace_secrets:
     whereabouts-api:

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/config/AsyncConfiguration.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/config/AsyncConfiguration.kt
@@ -2,11 +2,13 @@ package uk.gov.justice.digital.hmpps.whereabouts.config
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import java.util.concurrent.Executor
 
 @Configuration
+@Profile("!test")
 @EnableAsync
 class AsyncConfiguration {
 

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/config/AsyncConfiguration.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/config/AsyncConfiguration.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.whereabouts.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.Executor
+
+@Configuration
+@EnableAsync
+class AsyncConfiguration {
+
+  @Bean
+  fun asyncExecutor(): Executor? = ThreadPoolTaskExecutor().apply {
+    corePoolSize = 2
+    maxPoolSize = 2
+    queueCapacity = 10
+    threadNamePrefix = "AsyncThread-"
+    initialize()
+  }
+}

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/config/FeatureSwitches.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/config/FeatureSwitches.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.whereabouts.config
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.core.env.Environment
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.whereabouts.services.court.events.OutboundEvent
+
+/**
+ * A centralised reusable component for determining whether an application feature is enabled or not.
+ */
+@Component
+class FeatureSwitches(private val environment: Environment) {
+
+  companion object {
+    private val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun isEnabled(feature: Feature, defaultValue: Boolean = false): Boolean =
+    get(feature.label, Boolean::class.java, defaultValue)
+
+  fun isEnabled(outboundEvent: OutboundEvent, defaultValue: Boolean = false): Boolean =
+    get("feature.event.${outboundEvent.eventType}", Boolean::class.java, defaultValue)
+
+  private inline fun <reified T> get(property: String, type: Class<T>, defaultValue: T) =
+    environment.getProperty(property, type).let {
+      if (it == null) {
+        log.info("property '$property' not configured, defaulting to $defaultValue")
+        defaultValue
+      } else {
+        it
+      }
+    }
+}
+
+enum class Feature(val label: String) {
+  OUTBOUND_EVENTS_ENABLED("feature.events.sns.enabled"),
+}

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/controllers/VideoLinkMigrationController.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/controllers/VideoLinkMigrationController.kt
@@ -53,11 +53,11 @@ class VideoLinkMigrationController(
   )
   @PreAuthorize("hasAnyRole('BOOK_A_VIDEO_LINK_ADMIN')")
   fun migrateVideoLinkBookings(
-    @Parameter(
-      description = "The start date to migrate bookings with a creation date on or after this date, Defaults to 5 days ago",
-      required = true,
-      example = "2023-10-01",
-    )
+    @Parameter(description = "Earliest date for the main hearing time", required = true, example = "2023-10-01")
     fromDate: LocalDate,
-  ) = videoLinkMigrationService.migrateVideoLinkBookingsSinceDate(fromDate)
+    @Parameter(description = "Page size", required = false, example = "10")
+    pageSize: Int = 10,
+    @Parameter(description = "Milliseconds to delay between pages")
+    waitMillis: Long = 0,
+  ) = videoLinkMigrationService.migrateVideoLinkBookingsSinceDate(fromDate, pageSize, waitMillis)
 }

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/controllers/VideoLinkMigrationController.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/controllers/VideoLinkMigrationController.kt
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.whereabouts.services.court.VideoLinkMigrationService
@@ -54,10 +55,10 @@ class VideoLinkMigrationController(
   @PreAuthorize("hasAnyRole('BOOK_A_VIDEO_LINK_ADMIN')")
   fun migrateVideoLinkBookings(
     @Parameter(description = "Earliest date for the main hearing time", required = true, example = "2023-10-01")
-    fromDate: LocalDate,
-    @Parameter(description = "Page size", required = false, example = "10")
-    pageSize: Int = 10,
-    @Parameter(description = "Milliseconds to delay between pages")
-    waitMillis: Long = 0,
+    @RequestParam fromDate: LocalDate,
+    @Parameter(description = "Page size. Will default to 10 if not provided", required = false, example = "10")
+    @RequestParam pageSize: Int = 10,
+    @Parameter(description = "Milliseconds to delay between pages. Defaults to no delay (0 milliseconds)")
+    @RequestParam waitMillis: Long = 0,
   ) = videoLinkMigrationService.migrateVideoLinkBookingsSinceDate(fromDate, pageSize, waitMillis)
 }

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/repository/VideoLinkBookingEventRepository.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/repository/VideoLinkBookingEventRepository.kt
@@ -50,7 +50,7 @@ interface VideoLinkBookingEventRepository : JpaRepository<VideoLinkBookingEvent,
 
   fun findEventsByVideoLinkBookingId(videoLinkBookingId: Long): List<VideoLinkBookingEvent>
 
-  fun findAllByTimestampGreaterThanAndEventTypeEquals(
+  fun findAllByMainStartTimeGreaterThanAndEventTypeEquals(
     fromDate: LocalDateTime,
     eventType: VideoLinkBookingEventType = VideoLinkBookingEventType.CREATE,
     pageable: Pageable,

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/repository/VideoLinkBookingEventRepository.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/repository/VideoLinkBookingEventRepository.kt
@@ -4,16 +4,20 @@ import jakarta.persistence.QueryHint
 import org.hibernate.jpa.AvailableHints.HINT_CACHEABLE
 import org.hibernate.jpa.AvailableHints.HINT_FETCH_SIZE
 import org.hibernate.jpa.AvailableHints.HINT_READ_ONLY
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.jpa.repository.QueryHints
+import org.springframework.data.repository.PagingAndSortingRepository
 import org.springframework.data.repository.query.Param
 import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkBookingEvent
+import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkBookingEventType
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.stream.Stream
 
-interface VideoLinkBookingEventRepository : JpaRepository<VideoLinkBookingEvent, Long> {
+interface VideoLinkBookingEventRepository : JpaRepository<VideoLinkBookingEvent, Long>, PagingAndSortingRepository<VideoLinkBookingEvent, Long> {
   @QueryHints(
     value = [
       QueryHint(name = HINT_FETCH_SIZE, value = "" + Integer.MAX_VALUE),
@@ -45,6 +49,12 @@ interface VideoLinkBookingEventRepository : JpaRepository<VideoLinkBookingEvent,
   ): Stream<VideoLinkBookingEvent>
 
   fun findEventsByVideoLinkBookingId(videoLinkBookingId: Long): List<VideoLinkBookingEvent>
+
+  fun findAllByTimestampGreaterThanAndEventTypeEquals(
+    fromDate: LocalDateTime,
+    eventType: VideoLinkBookingEventType = VideoLinkBookingEventType.CREATE,
+    pageable: Pageable,
+  ): Page<VideoLinkBookingEvent>
 }
 
 fun VideoLinkBookingEventRepository.findByDatesBetween(

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/VideoLinkMigrationService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/VideoLinkMigrationService.kt
@@ -51,7 +51,7 @@ class VideoLinkMigrationService(
 
     val elapsed = measureTimeMillis {
       // Change to use the main hearing date - this is what Emma preferred
-      var page = videoLinkBookingEventRepository.findAllByTimestampGreaterThanAndEventTypeEquals(
+      var page = videoLinkBookingEventRepository.findAllByMainStartTimeGreaterThanAndEventTypeEquals(
         LocalDateTime.of(fromDate.year, fromDate.month, fromDate.dayOfMonth, 0, 0),
         VideoLinkBookingEventType.CREATE,
         pageable,
@@ -71,7 +71,7 @@ class VideoLinkMigrationService(
         }
 
         // Get the next page of create events
-        page = videoLinkBookingEventRepository.findAllByTimestampGreaterThanAndEventTypeEquals(
+        page = videoLinkBookingEventRepository.findAllByMainStartTimeGreaterThanAndEventTypeEquals(
           LocalDateTime.of(fromDate.year, fromDate.month, fromDate.dayOfMonth, 0, 0),
           VideoLinkBookingEventType.CREATE,
           pageable.next(),

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/VideoLinkMigrationService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/VideoLinkMigrationService.kt
@@ -55,7 +55,7 @@ class VideoLinkMigrationService(
 
     val elapsed = measureTimeMillis {
       var page = videoLinkBookingEventRepository.findAllByMainStartTimeGreaterThanAndEventTypeEquals(
-        LocalDateTime.of(fromDate.year, fromDate.month, fromDate.dayOfMonth, 0, 0),
+        fromDate.atStartOfDay(),
         VideoLinkBookingEventType.CREATE,
         pageable.first(),
       )
@@ -78,7 +78,7 @@ class VideoLinkMigrationService(
         }
 
         page = videoLinkBookingEventRepository.findAllByMainStartTimeGreaterThanAndEventTypeEquals(
-          LocalDateTime.of(fromDate.year, fromDate.month, fromDate.dayOfMonth, 0, 0),
+          fromDate.atStartOfDay(),
           VideoLinkBookingEventType.CREATE,
           pageable.next(),
         )

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/events/OutboundEvents.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/events/OutboundEvents.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.whereabouts.services.court.events
+import java.time.LocalDateTime
+
+enum class OutboundEvent(val eventType: String) {
+  VIDEO_LINK_BOOKING_MIGRATE("whereabouts-api.videolink.migrate") {
+    override fun event(additionalInformation: AdditionalInformation) =
+      OutboundHMPPSDomainEvent(
+        eventType = eventType,
+        additionalInformation = additionalInformation,
+        description = "A video link booking has been identified for migration",
+      )
+  },
+  ;
+
+  abstract fun event(additionalInformation: AdditionalInformation): OutboundHMPPSDomainEvent
+}
+
+interface AdditionalInformation
+
+data class OutboundHMPPSDomainEvent(
+  val eventType: String,
+  val additionalInformation: AdditionalInformation,
+  val version: String = "1",
+  val description: String,
+  val occurredAt: LocalDateTime = LocalDateTime.now(),
+)
+
+data class VideoLinkBookingMigrate(val videoLinkBookingId: Long) : AdditionalInformation

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/events/OutboundEventsPublisher.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/events/OutboundEventsPublisher.kt
@@ -1,0 +1,51 @@
+package uk.gov.justice.digital.hmpps.whereabouts.services.court.events
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue
+import software.amazon.awssdk.services.sns.model.PublishRequest
+import uk.gov.justice.digital.hmpps.whereabouts.config.Feature
+import uk.gov.justice.digital.hmpps.whereabouts.config.FeatureSwitches
+import uk.gov.justice.hmpps.sqs.HmppsQueueService
+
+@Service
+class OutboundEventsPublisher(
+  private val hmppsQueueService: HmppsQueueService,
+  private val mapper: ObjectMapper,
+  features: FeatureSwitches,
+) {
+  private val outboundEventsEnabled = features.isEnabled(Feature.OUTBOUND_EVENTS_ENABLED)
+
+  companion object {
+    const val TOPIC_ID = "domainevents"
+    private val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  init {
+    log.info("Outbound SNS event publishing enabled = $outboundEventsEnabled")
+  }
+
+  private val domainEventsTopic by lazy {
+    hmppsQueueService.findByTopicId(TOPIC_ID) ?: throw RuntimeException("Topic with name $TOPIC_ID doesn't exist")
+  }
+
+  fun send(event: OutboundHMPPSDomainEvent) {
+    if (outboundEventsEnabled) {
+      domainEventsTopic.snsClient.publish(
+        PublishRequest.builder()
+          .topicArn(domainEventsTopic.arn)
+          .message(mapper.writeValueAsString(event))
+          .messageAttributes(metaData(event))
+          .build(),
+      ).also { log.debug("Published {}", event) }
+
+      return
+    }
+    log.info("Ignoring publishing of event $event (feature switched off)")
+  }
+
+  private fun metaData(payload: OutboundHMPPSDomainEvent) =
+    mapOf("eventType" to MessageAttributeValue.builder().dataType("String").stringValue(payload.eventType).build())
+}

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/events/OutboundEventsService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/events/OutboundEventsService.kt
@@ -14,7 +14,7 @@ class OutboundEventsService(
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun send(outboundEvent: OutboundEvent, identifier: Long, secondIdentifier: Long? = null) {
+  fun send(outboundEvent: OutboundEvent, identifier: Long) {
     if (featureSwitches.isEnabled(outboundEvent)) {
       log.info("Sending outbound event $outboundEvent for identifier $identifier")
       when (outboundEvent) {

--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/events/OutboundEventsService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/court/events/OutboundEventsService.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.whereabouts.services.court.events
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.whereabouts.config.FeatureSwitches
+
+@Service
+class OutboundEventsService(
+  private val publisher: OutboundEventsPublisher,
+  private val featureSwitches: FeatureSwitches,
+) {
+  companion object {
+    private val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun send(outboundEvent: OutboundEvent, identifier: Long, secondIdentifier: Long? = null) {
+    if (featureSwitches.isEnabled(outboundEvent)) {
+      log.info("Sending outbound event $outboundEvent for identifier $identifier")
+      when (outboundEvent) {
+        OutboundEvent.VIDEO_LINK_BOOKING_MIGRATE -> {
+          publisher.send(outboundEvent.event(VideoLinkBookingMigrate(identifier)))
+        }
+      }
+    } else {
+      log.warn("Outbound event type $outboundEvent feature is configured off.")
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/config/TestAsyncConfiguration.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/config/TestAsyncConfiguration.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.whereabouts.config
+
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Profile
+import org.springframework.core.task.SyncTaskExecutor
+import java.util.concurrent.Executor
+
+@Profile("test")
+@TestConfiguration
+class TestAsyncConfiguration {
+
+  @Bean
+  fun asyncExecutor(): Executor? = SyncTaskExecutor()
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/VideoLinkMigrationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/VideoLinkMigrationServiceTest.kt
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.kotlin.any
-import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -14,8 +13,6 @@ import org.mockito.kotlin.whenever
 import org.springframework.beans.support.PagedListHolder
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
-import org.springframework.test.context.ContextConfiguration
-import uk.gov.justice.digital.hmpps.whereabouts.config.TestAsyncConfiguration
 import uk.gov.justice.digital.hmpps.whereabouts.model.HearingType
 import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkAppointment
 import uk.gov.justice.digital.hmpps.whereabouts.model.VideoLinkBookingEvent
@@ -32,7 +29,6 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.Optional
 
-@ContextConfiguration(classes = [TestAsyncConfiguration::class])
 class VideoLinkMigrationServiceTest {
   private val videoLinkAppointmentRepository: VideoLinkAppointmentRepository = mock()
   private val videoLinkBookingRepository: VideoLinkBookingRepository = mock()
@@ -164,7 +160,7 @@ class VideoLinkMigrationServiceTest {
       assertThat(numberOfEventsRaised).isEqualTo(5)
     }
 
-    verify(outboundEventsService, times(5)).send(any(), anyLong(), anyOrNull())
+    verify(outboundEventsService, times(5)).send(any(), anyLong())
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/VideoLinkMigrationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/VideoLinkMigrationServiceTest.kt
@@ -87,7 +87,7 @@ class VideoLinkMigrationServiceTest {
     val fromDateTime = LocalDateTime.of(fromDate.year, fromDate.month, fromDate.dayOfMonth, 0, 0)
     val pageable = Pageable.ofSize(10).first()
 
-    whenever(videoLinkBookingEventRepository.findAllByTimestampGreaterThanAndEventTypeEquals(fromDateTime, VideoLinkBookingEventType.CREATE, pageable))
+    whenever(videoLinkBookingEventRepository.findAllByMainStartTimeGreaterThanAndEventTypeEquals(fromDateTime, VideoLinkBookingEventType.CREATE, pageable))
       .thenReturn(
         PageImpl(
           listOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/court/OutboundEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/court/OutboundEventsServiceTest.kt
@@ -1,0 +1,83 @@
+package uk.gov.justice.digital.hmpps.whereabouts.services.court
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.stub
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
+import uk.gov.justice.digital.hmpps.whereabouts.config.Feature
+import uk.gov.justice.digital.hmpps.whereabouts.config.FeatureSwitches
+import uk.gov.justice.digital.hmpps.whereabouts.services.court.events.AdditionalInformation
+import uk.gov.justice.digital.hmpps.whereabouts.services.court.events.OutboundEvent
+import uk.gov.justice.digital.hmpps.whereabouts.services.court.events.OutboundEventsPublisher
+import uk.gov.justice.digital.hmpps.whereabouts.services.court.events.OutboundEventsService
+import uk.gov.justice.digital.hmpps.whereabouts.services.court.events.OutboundHMPPSDomainEvent
+import uk.gov.justice.digital.hmpps.whereabouts.services.court.events.VideoLinkBookingMigrate
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+/**
+ * These tests are only required for Video link booking migration from whereabouts API
+ * into the new hmpps-book-a-video-link service.  These can be removed later.
+ */
+class OutboundEventsServiceTest {
+
+  private val eventsPublisher: OutboundEventsPublisher = mock()
+  private val featureSwitches: FeatureSwitches = mock()
+  private val outboundEventsService = OutboundEventsService(eventsPublisher, featureSwitches)
+  private val eventCaptor = argumentCaptor<OutboundHMPPSDomainEvent>()
+
+  @Test
+  fun `video link booking migration event is published with correct content`() {
+    featureSwitches.stub { on { isEnabled(OutboundEvent.VIDEO_LINK_BOOKING_MIGRATE) } doReturn true }
+
+    outboundEventsService.send(OutboundEvent.VIDEO_LINK_BOOKING_MIGRATE, 1L)
+
+    verify(
+      expectedEventType = "whereabouts-api.videolink.migrate",
+      expectedAdditionalInformation = VideoLinkBookingMigrate(1),
+      expectedDescription = "A video link booking has been identified for migration",
+    )
+  }
+
+  @Test
+  fun `video link booking migrate event is feature-switched off - no event sent`() {
+    featureSwitches.stub { on { isEnabled(OutboundEvent.VIDEO_LINK_BOOKING_MIGRATE) } doReturn false }
+
+    outboundEventsService.send(OutboundEvent.VIDEO_LINK_BOOKING_MIGRATE, 1L)
+
+    verifyNoInteractions(eventsPublisher)
+  }
+
+  @Test
+  fun `all SNS event publishing is feature-switched off - no event sent`() {
+    featureSwitches.stub { on { isEnabled(Feature.OUTBOUND_EVENTS_ENABLED) } doReturn false }
+
+    outboundEventsService.send(OutboundEvent.VIDEO_LINK_BOOKING_MIGRATE, 1L)
+
+    verifyNoInteractions(eventsPublisher)
+  }
+
+  private fun verify(
+    expectedEventType: String,
+    expectedAdditionalInformation: AdditionalInformation,
+    expectedOccurredAt: LocalDateTime = LocalDateTime.now(),
+    expectedDescription: String,
+  ) {
+    verify(eventsPublisher).send(eventCaptor.capture())
+
+    with(eventCaptor.firstValue) {
+      assertThat(eventType).isEqualTo(expectedEventType)
+      assertThat(additionalInformation).isEqualTo(expectedAdditionalInformation)
+      assertThat(occurredAt).isCloseTo(expectedOccurredAt, within(60, ChronoUnit.SECONDS))
+      assertThat(description).isEqualTo(expectedDescription)
+    }
+
+    verifyNoMoreInteractions(eventsPublisher)
+  }
+}


### PR DESCRIPTION
* Adds an outbound events service/publisher and defines the migration event `whereabouts-api.videolink.migrate`
* Adds a feature switching service and switches outbound event ON in DEV only.
* Adds a paginated video link booking event selection repo method (mainStartTime > fromDate)
* Adds a new method to page through the CREATE events matching the criteria and emit an event for each booking.
* Tests