### PR TITLE
BAVL-41 missing domain events topic from config, needed so we can publish to it.

### DIFF
--- a/helm_deploy/whereabouts-api/values.yaml
+++ b/helm_deploy/whereabouts-api/values.yaml
@@ -59,7 +59,8 @@ generic-service:
       HMPPS_SQS_QUEUES_DOMAINEVENT_QUEUE_NAME: "sqs_name"
     whereabouts-api-domain-events-sqs-dl-instance-output:
       HMPPS_SQS_QUEUES_DOMAINEVENT_DLQ_NAME: "sqs_name"
-
+    hmpps-domain-events-topic:
+      HMPPS_SQS_TOPICS_DOMAINEVENTS_ARN: "topic_arn"
 
 
   allowlist:


### PR DESCRIPTION
It looks like the config for publishing domain events for migration is not present in the helm config.  Added here.

Note this also requires a cloud platform change, linked [here](https://github.com/ministryofjustice/cloud-platform-environments/pull/26161).