### PR TITLE
BAVL-41 move domain events topic subscription queue config to dev only, otherwise would impact release to higher environments.

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -13,6 +13,10 @@ generic-service:
     PRISONREGISTER_ENDPOINT_URL: "https://prison-register-dev.hmpps.service.justice.gov.uk"
     FEATURE_EVENTS_SNS_ENABLED: true
 
+  namespace_secrets:
+    hmpps-domain-events-topic:
+      HMPPS_SQS_TOPICS_DOMAINEVENTS_ARN: "topic_arn"
+
   allowlist:
     groups:
       - internal

--- a/helm_deploy/whereabouts-api/values.yaml
+++ b/helm_deploy/whereabouts-api/values.yaml
@@ -59,9 +59,6 @@ generic-service:
       HMPPS_SQS_QUEUES_DOMAINEVENT_QUEUE_NAME: "sqs_name"
     whereabouts-api-domain-events-sqs-dl-instance-output:
       HMPPS_SQS_QUEUES_DOMAINEVENT_DLQ_NAME: "sqs_name"
-    hmpps-domain-events-topic:
-      HMPPS_SQS_TOPICS_DOMAINEVENTS_ARN: "topic_arn"
-
 
   allowlist:
     groups:


### PR DESCRIPTION
Having the SNS topic subscription in the overarching values.yaml file would potentially impact releasing to higher environments without the necessary cloud platform queue configuration in place.