### PR TITLE
BAVL-376 migration changes to cater for deleted bookings missing their corresponding delete event.

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/listeners/SqsDomainEventListener.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/listeners/SqsDomainEventListener.kt
@@ -23,31 +23,32 @@ class SqsDomainEventListener(
   }
 
   init {
-    log.info("BVLS enabled=$bvlsEnabled for domain events")
+    log.info("Legacy BVLS enabled=$bvlsEnabled for domain events")
   }
 
   @SqsListener("domainevent", factory = "hmppsQueueContainerFactoryProxy")
   @WithSpan(value = "map-devs-hmpps_whereabouts_api_domain_queue", kind = SpanKind.SERVER)
   fun handleDomainEvents(requestJson: String?) {
-    if (bvlsEnabled) {
-      try {
-        log.info("Raw domain event message: {}", requestJson)
-        val (message, messageAttributes) = gson.fromJson(requestJson, Message::class.java)
-        val eventType = messageAttributes.eventType.value
-        log.info("Processing message of type {}", eventType)
+    try {
+      log.info("Raw domain event message: {}", requestJson)
+      val (message, messageAttributes) = gson.fromJson(requestJson, Message::class.java)
+      val eventType = messageAttributes.eventType.value
+      log.info("Processing message of type {}", eventType)
 
-        when (eventType) {
-          "prison-offender-events.prisoner.released" -> {
-            val transferEventMessage = gson.fromJson(message, ReleasedOffenderEventMessage::class.java)
+      when (eventType) {
+        "prison-offender-events.prisoner.released" -> {
+          val transferEventMessage = gson.fromJson(message, ReleasedOffenderEventMessage::class.java)
+
+          if (bvlsEnabled) {
             videoLinkBookingService.deleteAppointmentWhenTransferredOrReleased(transferEventMessage)
+          } else {
+            log.info("Legacy BVLS event processing is disabled, ignoring release event - {}", transferEventMessage)
           }
         }
-      } catch (e: Exception) {
-        log.error("processDomainEvent() Unexpected error", e)
-        throw e
       }
-    } else {
-      log.info("Ignoring domain events for BVLS, BVLS feature is disabled.")
+    } catch (e: Exception) {
+      log.error("processDomainEvent() Unexpected error", e)
+      throw e
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/VideoLinkMigrationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/whereabouts/services/VideoLinkMigrationServiceTest.kt
@@ -198,6 +198,7 @@ class VideoLinkMigrationServiceTest {
     whenever(videoLinkBookingRepository.findById(videoBookingId)).thenReturn(Optional.of(booking))
     whenever(videoLinkAppointmentRepository.findAllByVideoLinkBooking(booking)).thenReturn(appointments)
     whenever(videoLinkBookingEventRepository.findEventsByVideoLinkBookingId(videoBookingId)).thenReturn(events)
+    whenever(videoLinkBookingRepository.existsById(videoBookingId)) doReturn true
 
     val response = videoLinkMigrationService.getVideoLinkBookingToMigrate(3)
 
@@ -238,6 +239,7 @@ class VideoLinkMigrationServiceTest {
     whenever(videoLinkBookingRepository.findById(videoBookingId)).thenReturn(Optional.of(booking))
     whenever(videoLinkAppointmentRepository.findAllByVideoLinkBooking(booking)).thenReturn(appointments)
     whenever(videoLinkBookingEventRepository.findEventsByVideoLinkBookingId(videoBookingId)).thenReturn(events)
+    whenever(videoLinkBookingRepository.existsById(videoBookingId)) doReturn true
 
     val response = videoLinkMigrationService.getVideoLinkBookingToMigrate(3)
 
@@ -266,6 +268,7 @@ class VideoLinkMigrationServiceTest {
     whenever(videoLinkAppointmentRepository.findAllByVideoLinkBooking(booking)).thenReturn(appointments)
     whenever(videoLinkBookingEventRepository.findEventsByVideoLinkBookingId(videoBookingId)).thenReturn(events)
     whenever(courtService.getCourtNameForCourtId("PROBYRK")) doReturn " ProBation "
+    whenever(videoLinkBookingRepository.existsById(videoBookingId)) doReturn true
 
     val response = videoLinkMigrationService.getVideoLinkBookingToMigrate(3)
 
@@ -293,6 +296,7 @@ class VideoLinkMigrationServiceTest {
     whenever(videoLinkBookingRepository.findById(videoBookingId)).thenReturn(Optional.of(booking))
     whenever(videoLinkAppointmentRepository.findAllByVideoLinkBooking(booking)).thenReturn(appointments)
     whenever(videoLinkBookingEventRepository.findEventsByVideoLinkBookingId(videoBookingId)).thenReturn(events)
+    whenever(videoLinkBookingRepository.existsById(videoBookingId)) doReturn true
 
     val response = videoLinkMigrationService.getVideoLinkBookingToMigrate(3)
 
@@ -320,6 +324,7 @@ class VideoLinkMigrationServiceTest {
     whenever(videoLinkBookingRepository.findById(videoBookingId)).thenReturn(Optional.of(booking))
     whenever(videoLinkAppointmentRepository.findAllByVideoLinkBooking(booking)).thenReturn(appointments)
     whenever(videoLinkBookingEventRepository.findEventsByVideoLinkBookingId(videoBookingId)).thenReturn(events)
+    whenever(videoLinkBookingRepository.existsById(videoBookingId)) doReturn true
 
     assertThrows(IllegalArgumentException::class.java) {
       videoLinkMigrationService.getVideoLinkBookingToMigrate(3)
@@ -424,6 +429,7 @@ class VideoLinkMigrationServiceTest {
     whenever(videoLinkBookingRepository.findById(videoBookingId)).thenReturn(Optional.of(booking))
     whenever(videoLinkAppointmentRepository.findAllByVideoLinkBooking(booking)).thenReturn(appointments)
     whenever(videoLinkBookingEventRepository.findEventsByVideoLinkBookingId(videoBookingId)).thenReturn(events)
+    whenever(videoLinkBookingRepository.existsById(videoBookingId)) doReturn true
 
     assertThrows(IllegalArgumentException::class.java) {
       videoLinkMigrationService.getVideoLinkBookingToMigrate(3)
@@ -484,6 +490,7 @@ class VideoLinkMigrationServiceTest {
     whenever(videoLinkBookingRepository.findById(videoBookingId)).thenReturn(Optional.of(booking))
     whenever(videoLinkAppointmentRepository.findAllByVideoLinkBooking(booking)).thenReturn(appointments)
     whenever(videoLinkBookingEventRepository.findEventsByVideoLinkBookingId(videoBookingId)).thenReturn(events)
+    whenever(videoLinkBookingRepository.existsById(videoBookingId)) doReturn true
 
     assertThrows(IllegalArgumentException::class.java) {
       videoLinkMigrationService.getVideoLinkBookingToMigrate(3)


### PR DESCRIPTION
During migration testing a discrepancy occurred where we were unable to migrate 1830 old bookings

We have identified these bookings as deleted but don’t they have any corresponding delete event.

In order to migrate these we create a FAKE delete event for these bookings.